### PR TITLE
V2.1.1

### DIFF
--- a/apps/backend/models/DictWildcardLookup.py
+++ b/apps/backend/models/DictWildcardLookup.py
@@ -1,0 +1,29 @@
+"""
+Pydantic Model representing information about a wilcard
+dictionary lookup pattern used by `/dict/wildcard` endpoint.
+"""
+
+from pydantic import BaseModel
+from typing import List
+from models.JMEntry import JMEntry
+from models.JMNEntry import JMNEntry
+from models.KanjiInfo import KanjiInfo
+
+
+class DictWildcardLookup(BaseModel):
+    """
+    Pydantic Model representing information
+    extracted from kotobase for a query word.
+
+    Args:
+      pattern (str): Query word.
+      jmentries (list): List of JMEntry models.
+      jmnentries (list): List of JMNEntry models.
+      kanji (list): List of KanjiInfo models.
+      examples (list): List of example sentences.
+    """
+    pattern: str
+    jmentries: List[JMEntry]
+    jmnentries: List[JMNEntry]
+    kanji: List[KanjiInfo]
+    examples: List[str]

--- a/apps/backend/processing/text_processing.py
+++ b/apps/backend/processing/text_processing.py
@@ -21,6 +21,7 @@ from models.KanjiInfo import KanjiInfo
 from models.WordSense import WordSense
 from models.JMEntry import JMEntry
 from models.JMNEntry import JMNEntry
+from models.DictWildcardLookup import DictWildcardLookup
 from models.BreakdownResponse import BreakdownResponse
 import logging
 
@@ -176,6 +177,34 @@ In your response:
                          )
         result = model.request(prompt)
         return result['response']
+
+
+@lru_cache(maxsize=1024)
+def _query_kotobase_wildcard(pattern: str) -> Dict:
+    """
+    Wrapper for `kotobase.Kotobase.lookup` with lru cache and result
+    processing for wildcard pattern
+
+    Args:
+        pattern (str): Wilcard pattern
+
+    Returns:
+        dict: Extracted pattern information.
+    """
+    l_result = Kotobase().lookup(word=pattern,
+                                 wildcard=True,
+                                 include_names=True,
+                                 sentence_limit=5
+                                 )
+    examples = (
+        [st.text for st in l_result.examples] if l_result.examples else []
+        )
+    split_entries = l_result.filter_entries()
+    return {"result": l_result,
+            "examples": examples,
+            "jmdict": split_entries["jmdict"],
+            "jmnedict": split_entries["jmnedict"]
+            }
 
 
 @lru_cache(maxsize=1024)
@@ -422,6 +451,107 @@ class SentenceBreakdownService:
             kanji=kanji_lst,
             meanings=meanings,
             jlpt=jlpt,
+            examples=examples
+            )
+
+    def wildcard_lookup(self,
+                        pattern: str
+                        ) -> DictWildcardLookup:
+        """
+        Perform a kotobase search for a wildcard pattern and
+        return results formatted into a pydantic model
+
+        Args:
+          pattern (str): The wildcard pattern
+
+        Returns:
+          DictWildcardLookup: Pydantic model containing kotobase info
+
+        """
+        query = _query_kotobase_wildcard(pattern=pattern)
+        result: LookupResult
+        result = query["result"]
+        default_sense = [WordSense(order=99, pos="", gloss="")]
+        default_jmentry = JMEntry(rank=99,
+                                  kana=[],
+                                  kanji=[],
+                                  senses=default_sense
+                                  )
+        default_jmnentry = JMNEntry(kana=[],
+                                    kanji=[],
+                                    translation_type="",
+                                    gloss=[]
+                                    )
+        default_kanjiinfo = KanjiInfo(
+                    literal="",
+                    grade=None,
+                    stroke_count=99,
+                    meanings=[],
+                    onyomi=[],
+                    kunyomi=[],
+                    jlpt_kanjidic=None,
+                    jlpt_tanos=None
+                    )
+        jmentries = []
+        jmnentries = []
+        kanji_lst = []
+        examples = query["examples"]
+        # Build Entries
+        if result.entries:
+            for entry in result.entries:
+                if isinstance(entry, JMDictEntryDTO):
+                    # Senses
+                    if entry.senses:
+                        jm_senses = [WordSense(order=sense["order"],
+                                               pos=sense["pos"],
+                                               gloss=sense["gloss"]
+                                               ) for sense in entry.senses
+                                     ]
+                    else:
+                        jm_senses = [WordSense(order=99, pos="", gloss="")]
+                    # Other Fields
+                    jm_kana = entry.kana
+                    jm_kanji = entry.kanji
+                    jm_rank = entry.rank
+                    jmentries.append(JMEntry(rank=jm_rank,
+                                             kana=jm_kana,
+                                             kanji=jm_kanji,
+                                             senses=jm_senses
+                                             ))
+                elif isinstance(entry, JMNeDictEntryDTO):
+                    jmne_kana = entry.kana
+                    jmne_kanji = entry.kanji
+                    jmne_tt = entry.translation_type
+                    jmne_gloss = entry.gloss
+                    jmnentries.append(JMNEntry(
+                        kana=jmne_kana,
+                        kanji=jmne_kanji,
+                        translation_type=jmne_tt,
+                        gloss=jmne_gloss))
+        else:
+            jmentries.append(default_jmentry)
+            jmnentries.append(default_jmnentry)
+        # Build KanjiInfo
+        if result.kanji:
+            for k in result.kanji:
+                kanji_lst.append(KanjiInfo(
+                    literal=k.literal,
+                    grade=k.grade,
+                    stroke_count=k.stroke_count,
+                    meanings=k.meanings,
+                    onyomi=k.onyomi,
+                    kunyomi=k.kunyomi,
+                    jlpt_kanjidic=k.jlpt_kanjidic,
+                    jlpt_tanos=k.jlpt_tanos))
+        else:
+            kanji_lst.append(default_kanjiinfo)
+
+        # Build Final Model
+        return DictWildcardLookup(
+            pattern=pattern,
+            jmentries=jmentries,
+            jmnentries=jmnentries,
+            kanji=kanji_lst,
             examples=examples
             )
 

--- a/apps/backend/routers/dict_router.py
+++ b/apps/backend/routers/dict_router.py
@@ -12,6 +12,7 @@ import logging
 from processing.Processor import Processor
 from utils.env_utils import using_modal
 from models.DictLookup import DictLookup
+from models.DictWildcardLookup import DictWildcardLookup
 
 USING_MODAL = using_modal()
 LOGGER = logging.getLogger(__name__)
@@ -62,6 +63,36 @@ async def query_word(word: str = Query(...)) -> DictLookup:
         return r
     except Exception as e:
         LOGGER.exception(f"Failed to query kotobase for word: '{word}'")
+        raise HTTPException(status_code=500,
+                            detail=str(e)
+                            )
+
+
+@dict_router.get("/wildcard", response_model=DictWildcardLookup)
+async def wildcard_query(pattern: str = Query(...)) -> DictWildcardLookup:
+    """
+    Endpoint returning dictionary information for a wildcard pattern lookup
+
+    Args:
+      pattern (str): Sentence to return tokens from.
+
+    Returns:
+      DictWildcardLookup: Pydantic Model containing wildcard pattern lookup
+                          information
+
+    Raises:
+      HTTPException: If lookup fails.
+    """
+    try:
+        # Append final wildcard if wildcard marker not present
+        if ("%" not in pattern) or ("*" not in pattern):
+            pattern += "*"
+        r = breakdown_service.wildcard_lookup(pattern)
+        return r
+    except Exception as e:
+        LOGGER.exception(
+            f"Failed to query kotobase for wildcard pattern: '{pattern}'"
+            )
         raise HTTPException(status_code=500,
                             detail=str(e)
                             )

--- a/apps/cli/mirumoji/pyproject.toml
+++ b/apps/cli/mirumoji/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mirumoji"
-version = "2.1.0"
+version = "2.1.1"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "CLI launcher for the Mirumoji project, an open-source, self-hostable Japanese language immersion tool."

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirumoji-ui",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "private": true,
     "type": "module",
     "scripts": {

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -13,6 +13,7 @@ import NotFoundPage from "./pages/NotFoundPage";
 import UserPage from "./pages/UserPage";
 import SavedPage from "./pages/SavedPage";
 import TextPage from "./pages/TextPage";
+import { DictionaryPage } from "./pages/DictionaryPage";
 /**
  * The main application component.
  *
@@ -31,6 +32,7 @@ function App() {
                     <Route path="/" element={<HomePage />} />
                     <Route path="/player" element={<PlayerPage />} />
                     <Route path="/text" element={<TextPage />} />
+                    <Route path="/dictionary" element={<DictionaryPage />} />
                     <Route path="*" element={<NotFoundPage />} />
                 </Routes>
             </main>

--- a/apps/frontend/src/components/DictDisplays.tsx
+++ b/apps/frontend/src/components/DictDisplays.tsx
@@ -3,8 +3,9 @@
  * such as JMdict entries, proper noun entries, and Kanji information.
  */
 
+import { useState } from "react";
 import { JMEntry, JMNEntry, KanjiInfo } from "../types/types";
-
+import { DictWildcardLookup } from "../types/types";
 /**
  * Displays a standard dictionary entry from JMdict.
  * @param {object} props - The component props.
@@ -136,5 +137,264 @@ export const KanjiInfoDisplay = ({
                 </p>
             </div>
         </div>
+    </div>
+);
+
+/**
+ * A comprehensive card that displays multiple JMdict entries, JMnedict entries, Kanji information, and examples
+ * in a well-divided, responsive card with a tabbed interface.
+ * @param {object} props - The component props.
+ * @param {string} props.word - The word that was looked up.
+ * @param {JMEntry[]} props.jmdictEntries - The standard dictionary entries.
+ * @param {JMNEntry[]} props.jmnedictEntries - The proper noun dictionary entries.
+ * @param {KanjiInfo[]} props.kanjiInfo - The Kanji information.
+ * @param {string[]} props.examples - The example sentences.
+ * @returns {JSX.Element} The rendered comprehensive card.
+ */
+export const ComprehensiveEntryCard = ({
+    word,
+    jmdictEntries,
+    jmnedictEntries,
+    kanjiInfo,
+    examples,
+}: {
+    word: string;
+    jmdictEntries: JMEntry[];
+    jmnedictEntries: JMNEntry[];
+    kanjiInfo: KanjiInfo[];
+    examples: string[];
+}) => {
+    const tabs = [];
+    if (jmdictEntries.length > 0) tabs.push("Definition");
+    if (jmnedictEntries.length > 0) tabs.push("Proper Noun");
+    if (kanjiInfo.length > 0) tabs.push("Kanji");
+    if (examples.length > 0) tabs.push("Examples");
+
+    const [activeTab, setActiveTab] = useState(tabs[0]);
+
+    // This ensures that even if the active tab has no content (e.g., after a new search),
+    // it defaults to the first available tab.
+    if (!tabs.includes(activeTab)) {
+        setActiveTab(tabs[0]);
+    }
+
+    return (
+        <div className="bg-neutral-900 border border-neutral-700 rounded-lg shadow-xl p-4 sm:p-6 w-full max-w-2xl mx-auto text-white">
+            <h2 className="text-4xl font-bold mb-4 text-center">{word}</h2>
+
+            <div className="border-b border-neutral-700 mb-4">
+                <nav
+                    className="-mb-px flex justify-center space-x-4"
+                    aria-label="Tabs"
+                >
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab}
+                            onClick={() => setActiveTab(tab)}
+                            className={`${
+                                activeTab === tab
+                                    ? "border-indigo-500 text-indigo-400"
+                                    : "border-transparent text-neutral-400 hover:text-neutral-200 hover:border-neutral-500"
+                            } whitespace-nowrap py-2 px-1 border-b-2 font-medium text-sm transition-colors duration-200`}
+                        >
+                            {tab}
+                        </button>
+                    ))}
+                </nav>
+            </div>
+
+            <div className="mt-4 max-h-[60vh] overflow-y-auto px-2 custom-scrollbar">
+                {activeTab === "Definition" &&
+                    jmdictEntries.map((entry, i) => (
+                        <JmdictEntryDisplay
+                            key={i}
+                            entry={entry}
+                            isLast={i === jmdictEntries.length - 1}
+                        />
+                    ))}
+                {activeTab === "Proper Noun" &&
+                    jmnedictEntries.map((entry, i) => (
+                        <JmnedictEntryDisplay
+                            key={i}
+                            entry={entry}
+                            isLast={i === jmnedictEntries.length - 1}
+                        />
+                    ))}
+                {activeTab === "Kanji" &&
+                    kanjiInfo.map((info, i) => (
+                        <KanjiInfoDisplay
+                            key={i}
+                            kanjiInfo={info}
+                            isLast={i === kanjiInfo.length - 1}
+                        />
+                    ))}
+                {activeTab === "Examples" &&
+                    examples.map((example, i) => (
+                        <ExampleDisplay
+                            key={i}
+                            example={example}
+                            isLast={i === examples.length - 1}
+                        />
+                    ))}
+            </div>
+        </div>
+    );
+};
+
+/**
+ * Displays the tabbed results from a wildcard search.
+ * @param {object} props - The component props.
+ * @param {DictWildcardLookup} props.results - The wildcard search results.
+ * @param {(word: string) => void} props.onWordSelect - Callback to handle when a word is selected.
+ * @returns {JSX.Element} The wildcard results component.
+ */
+export const WildcardResults = ({
+    results,
+    onWordSelect,
+}: {
+    results: DictWildcardLookup;
+    onWordSelect: (word: string) => void;
+}) => {
+    const tabs = [];
+    if (results.jmentries.length > 0) tabs.push("JMdict");
+    if (results.jmnentries.length > 0) tabs.push("JMnedict");
+    if (results.kanji.length > 0) tabs.push("Kanji");
+    if (results.examples.length > 0) tabs.push("Examples");
+
+    const [activeTab, setActiveTab] = useState(tabs[0] || "");
+
+    return (
+        <div className="bg-neutral-800 border border-neutral-700 rounded-lg shadow-lg mt-6 max-w-4xl mx-auto">
+            <div className="border-b border-neutral-700">
+                <nav
+                    className="-mb-px flex justify-center space-x-4 px-4"
+                    aria-label="Tabs"
+                >
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab}
+                            onClick={() => setActiveTab(tab)}
+                            className={`${
+                                activeTab === tab
+                                    ? "border-indigo-500 text-indigo-400"
+                                    : "border-transparent text-neutral-400 hover:text-neutral-200 hover:border-neutral-500"
+                            } whitespace-nowrap py-3 px-2 border-b-2 font-medium text-sm transition-colors duration-200`}
+                        >
+                            {tab}
+                        </button>
+                    ))}
+                </nav>
+            </div>
+            <div className="p-4 h-96 overflow-y-auto">
+                {activeTab === "JMdict" &&
+                    results.jmentries.map((entry, i) => (
+                        <JMEntryRow
+                            key={i}
+                            entry={entry}
+                            onSelect={onWordSelect}
+                        />
+                    ))}
+                {activeTab === "JMnedict" &&
+                    results.jmnentries.map((entry, i) => (
+                        <JMNEntryRow
+                            key={i}
+                            entry={entry}
+                            onSelect={onWordSelect}
+                        />
+                    ))}
+                {activeTab === "Kanji" &&
+                    results.kanji.map((kanji, i) => (
+                        <KanjiRow
+                            key={i}
+                            kanji={kanji}
+                            onSelect={onWordSelect}
+                        />
+                    ))}
+                {activeTab === "Examples" &&
+                    results.examples.map((ex, i) => (
+                        <p
+                            key={i}
+                            className="py-2 px-3 text-center text-neutral-300"
+                        >
+                            {ex}
+                        </p>
+                    ))}
+            </div>
+        </div>
+    );
+};
+
+/**
+ * Renders a clickable row for a JMdict entry.
+ * @param {object} props - The component props.
+ * @param {JMEntry} props.entry - The JMdict entry.
+ * @param {(word: string) => void} props.onSelect - Callback for when the row is clicked.
+ * @returns {JSX.Element} The JMdict entry row component.
+ */
+export const JMEntryRow = ({
+    entry,
+    onSelect,
+}: {
+    entry: JMEntry;
+    onSelect: (word: string) => void;
+}) => (
+    <div
+        onClick={() => onSelect(entry.kanji[0] || entry.kana[0])}
+        className="grid grid-cols-3 gap-4 items-center text-center py-2 px-3 rounded-md hover:bg-neutral-700 cursor-pointer transition-colors duration-150"
+    >
+        <p className="font-semibold">{entry.kanji.join("、")}</p>
+        <p className="text-neutral-300">{entry.kana.join("、")}</p>
+        <p className="text-sm text-neutral-400">
+            {entry.senses.map((s) => s.pos).join(", ")}
+        </p>
+    </div>
+);
+
+/**
+ * Renders a clickable row for a JMnedict entry.
+ * @param {object} props - The component props.
+ * @param {JMNEntry} props.entry - The JMnedict entry.
+ * @param {(word: string) => void} props.onSelect - Callback for when the row is clicked.
+ * @returns {JSX.Element} The JMnedict entry row component.
+ */
+const JMNEntryRow = ({
+    entry,
+    onSelect,
+}: {
+    entry: JMNEntry;
+    onSelect: (word: string) => void;
+}) => (
+    <div
+        onClick={() => onSelect(entry.kanji[0] || entry.kana[0])}
+        className="grid grid-cols-3 gap-4 items-center text-center py-2 px-3 rounded-md hover:bg-neutral-700 cursor-pointer transition-colors duration-150"
+    >
+        <p className="font-semibold">{entry.kanji.join("、")}</p>
+        <p className="text-neutral-300">{entry.kana.join("、")}</p>
+        <p className="text-sm text-neutral-400">{entry.translation_type}</p>
+    </div>
+);
+
+/**
+ * Renders a clickable row for a Kanji character.
+ * @param {object} props - The component props.
+ * @param {KanjiInfo} props.kanji - The Kanji information.
+ * @param {(word: string) => void} props.onSelect - Callback for when the row is clicked.
+ * @returns {JSX.Element} The Kanji row component.
+ */
+export const KanjiRow = ({
+    kanji,
+    onSelect,
+}: {
+    kanji: KanjiInfo;
+    onSelect: (word: string) => void;
+}) => (
+    <div
+        onClick={() => onSelect(kanji.literal)}
+        className="grid grid-cols-3 gap-4 items-center text-center py-2 px-3 rounded-md hover:bg-neutral-700 cursor-pointer transition-colors duration-150"
+    >
+        <p className="font-bold text-lg col-span-1">{kanji.literal}</p>
+        <p className="text-sm text-neutral-400 col-span-2">
+            {kanji.meanings.join(", ")}
+        </p>
     </div>
 );

--- a/apps/frontend/src/components/NavigationMenu.tsx
+++ b/apps/frontend/src/components/NavigationMenu.tsx
@@ -169,6 +169,13 @@ export default function NavigationMenu() {
                         >
                             Analyze Text
                         </Link>
+                        <Link
+                            to="/dictionary"
+                            onClick={() => setOpen(false)}
+                            className="w-full text-center px-3 py-2 rounded-md text-white transition-all duration-200 hover:bg-gray-700 block"
+                        >
+                            Dictionary
+                        </Link>
                     </div>
                 </nav>
             </aside>

--- a/apps/frontend/src/components/SubtitlePlayer.tsx
+++ b/apps/frontend/src/components/SubtitlePlayer.tsx
@@ -185,7 +185,9 @@ export default function SubtitlePlayer({
                                     onClick={() => {
                                         setDialog({
                                             sentence: activeCue.raw,
-                                            word: token.surface_form,
+                                            word: !(token.basic_form === "*")
+                                                ? token.basic_form
+                                                : token.surface_form,
                                             cueStart: activeCue.start,
                                             cueEnd: activeCue.end,
                                         });

--- a/apps/frontend/src/components/WordDialog.tsx
+++ b/apps/frontend/src/components/WordDialog.tsx
@@ -11,7 +11,7 @@ import remarkBreaks from "remark-breaks";
 import { Copy, Check, Bookmark } from "lucide-react";
 import { apiFetch } from "../services/api";
 import { toast } from "react-hot-toast";
-import { apiWordQuery } from "../services/dictApi";
+import { apiWordQuery, filterDictLookup } from "../services/dictApi";
 import { toastApiError } from "../utils/apiErrorToaster";
 import {
     GptTemplate,
@@ -181,45 +181,16 @@ export default function WordDialog({
         setDictData(undefined);
         apiWordQuery(word)
             .then((entry) => {
-                // Filter Empty Elements
-                if (entry) {
-                    // Empty element has stroke count of `99`
-                    entry.kanji = entry.kanji.filter(
-                        (k) => k.stroke_count !== 99
-                    );
-                    // Empty element has no `kana` and no `kanji` and one sense with order of `99`
-                    entry.jmentries = entry.jmentries.filter(
-                        (jme) =>
-                            (jme.kanji.length !== 0 || jme.kana.length !== 0) &&
-                            jme.senses.length !== 0 &&
-                            jme.senses[0].order !== 99
-                    );
-                    // Empty element has no `kana`, `kanji` or `gloss` and empty string as translation type
-                    entry.jmnentries = entry.jmnentries.filter(
-                        (jmne) =>
-                            (jmne.kanji.length !== 0 ||
-                                jmne.kana.length !== 0) &&
-                            jmne.gloss.length !== 0 &&
-                            jmne.translation_type !== ""
-                    );
-                }
-                // Empty response has empty lists and jlpt of `Unknown`
-                const noEntry =
-                    entry.kanji.length === 0 &&
-                    entry.jmentries.length === 0 &&
-                    entry.jmnentries.length === 0 &&
-                    entry.meanings.length === 0 &&
-                    entry.examples.length === 0 &&
-                    entry.jlpt === "Unknown";
-                if (!noEntry) {
-                    setDictData(entry);
+                const filteredEntry = filterDictLookup(entry);
+                if (filteredEntry) {
+                    setDictData(filteredEntry);
                     // Set Default SubTab when common entries aren't available
-                    if (entry?.jmentries.length === 0) {
-                        if (entry?.jmnentries.length > 0) {
+                    if (filteredEntry.jmentries.length === 0) {
+                        if (filteredEntry.jmnentries.length > 0) {
                             setDictTab("jmnedict");
-                        } else if (entry?.kanji.length > 0) {
+                        } else if (filteredEntry.kanji.length > 0) {
                             setDictTab("kanji");
-                        } else if (entry?.examples.length > 0) {
+                        } else if (filteredEntry.examples.length > 0) {
                             setDictTab("examples");
                         }
                     }

--- a/apps/frontend/src/pages/DictionaryPage.tsx
+++ b/apps/frontend/src/pages/DictionaryPage.tsx
@@ -1,0 +1,128 @@
+/**
+ * @fileoverview This file contains the DictionaryPage component, which allows users to search the dictionary
+ * for words and kanji using wildcard patterns. It displays results in a tabbed interface and shows
+ * detailed information when a result is selected.
+ */
+
+import { useState } from "react";
+import {
+    apiWildcardQuery,
+    apiWordQuery,
+    filterDictWildcardLookup,
+    filterDictLookup,
+} from "../services/dictApi";
+import { DictLookup, DictWildcardLookup } from "../types/types";
+import {
+    ComprehensiveEntryCard,
+    WildcardResults,
+} from "../components/DictDisplays";
+
+/**
+ * Renders the main dictionary search page.
+ * @returns {JSX.Element} The dictionary page component.
+ */
+export const DictionaryPage = () => {
+    const [pattern, setPattern] = useState("");
+    const [wildcardResult, setWildcardResult] =
+        useState<DictWildcardLookup | null>(null);
+    const [selectedWordResult, setSelectedWordResult] =
+        useState<DictLookup | null>(null);
+    const [selectedWord, setSelectedWord] = useState<string>("");
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    /**
+     * Handles the search for a wildcard pattern.
+     */
+    const handleSearch = async () => {
+        if (!pattern) return;
+        setIsLoading(true);
+        setError(null);
+        setSelectedWordResult(null);
+        setWildcardResult(null);
+        try {
+            const result = await apiWildcardQuery(pattern);
+            const filteredResult = filterDictWildcardLookup(result);
+            setWildcardResult(filteredResult);
+            if (!filteredResult) {
+                setError("No results found for your query.");
+            }
+        } catch (err) {
+            setError("Failed to fetch dictionary results.");
+            console.error(err);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    /**
+     * Handles the selection of a word from the wildcard results to fetch its detailed information.
+     * @param {string} word - The word to look up.
+     */
+    const handleWordSelect = async (word: string) => {
+        setIsLoading(true);
+        setError(null);
+        setSelectedWord(word);
+        try {
+            const result = await apiWordQuery(word);
+            setSelectedWordResult(filterDictLookup(result));
+        } catch (err) {
+            setError("Failed to fetch details for the selected word.");
+            console.error(err);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <div className="container mx-auto p-4 sm:p-6 text-white min-h-screen">
+            <h1 className="text-4xl font-bold mb-6 text-center text-indigo-400">
+                Dictionary
+            </h1>
+            <div className="flex flex-col sm:flex-row gap-2 mb-6 max-w-xl mx-auto">
+                <input
+                    type="text"
+                    value={pattern}
+                    onChange={(e) => setPattern(e.target.value)}
+                    onKeyDown={(e) => e.key === "Enter" && handleSearch()}
+                    placeholder="Word or wildcard pattern (e.g. *字*)"
+                    className="flex-grow bg-neutral-800 border border-neutral-700 rounded-md py-2 px-4 focus:ring-2 focus:ring-indigo-500 focus:outline-none transition"
+                />
+                <button
+                    onClick={handleSearch}
+                    disabled={isLoading}
+                    className="bg-indigo-600 hover:bg-indigo-700 disabled:bg-indigo-800 disabled:cursor-not-allowed text-white font-bold py-2 px-6 rounded-md transition-colors duration-200"
+                >
+                    {isLoading ? "Searching..." : "Search"}
+                </button>
+            </div>
+
+            {error && <p className="text-center text-red-400 mt-4">{error}</p>}
+
+            {wildcardResult && !selectedWordResult && (
+                <WildcardResults
+                    results={wildcardResult}
+                    onWordSelect={handleWordSelect}
+                />
+            )}
+
+            {selectedWordResult && (
+                <div className="mt-6 max-w-2xl mx-auto">
+                    <ComprehensiveEntryCard
+                        word={selectedWord}
+                        jmdictEntries={selectedWordResult.jmentries}
+                        jmnedictEntries={selectedWordResult.jmnentries}
+                        kanjiInfo={selectedWordResult.kanji}
+                        examples={selectedWordResult.examples}
+                    />
+                    <button
+                        onClick={() => setSelectedWordResult(null)}
+                        className="mt-4 bg-neutral-700 hover:bg-neutral-600 text-white font-bold py-2 px-4 rounded-md w-full"
+                    >
+                        Close
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};

--- a/apps/frontend/src/services/dictApi.ts
+++ b/apps/frontend/src/services/dictApi.ts
@@ -3,7 +3,7 @@
  */
 
 import { apiFetch } from "../services/api";
-import { DictLookup } from "../types/types";
+import { DictLookup, DictWildcardLookup } from "../types/types";
 
 /**
  * Queries the dictionary API for a word.
@@ -16,4 +16,116 @@ export async function apiWordQuery(word: string): Promise<DictLookup> {
         method: "GET",
     });
     return result;
+}
+
+/**
+ * Queries the dictionary API for a wildcard pattern.
+ *
+ * @param {string} pattern The pattern to query.
+ * @returns {Promise<DictWildcardLookup>} A promise that resolves to the dictionary wilcard lookup data.
+ */
+export async function apiWildcardQuery(
+    pattern: string
+): Promise<DictWildcardLookup> {
+    const result = apiFetch<DictWildcardLookup>(
+        `/dict/wildcard?pattern=${pattern}`,
+        {
+            method: "GET",
+        }
+    );
+    return result;
+}
+
+/**
+ * Filters empty placeholders from a `DictLookup` response object
+ * and returns `null` in case the response object is considered empty
+ *
+ * @param {DictLookup} dictLookup The DictLookup object
+ * @returns {DictLookup | null} The filtered object or null
+ */
+export function filterDictLookup(
+    dictLookup: DictLookup | null
+): DictLookup | null {
+    // Filter Empty Elements
+    if (dictLookup) {
+        // Empty element has stroke count of `99`
+        dictLookup.kanji = dictLookup.kanji.filter(
+            (k) => k.stroke_count !== 99
+        );
+        // Empty element has no `kana` and no `kanji` and one sense with order of `99`
+        dictLookup.jmentries = dictLookup.jmentries.filter(
+            (jme) =>
+                (jme.kanji.length !== 0 || jme.kana.length !== 0) &&
+                jme.senses.length !== 0 &&
+                jme.senses[0].order !== 99
+        );
+        // Empty element has no `kana`, `kanji` or `gloss` and empty string as translation type
+        dictLookup.jmnentries = dictLookup.jmnentries.filter(
+            (jmne) =>
+                (jmne.kanji.length !== 0 || jmne.kana.length !== 0) &&
+                jmne.gloss.length !== 0 &&
+                jmne.translation_type !== ""
+        );
+    } else {
+        return null;
+    }
+    // Empty response has empty lists and jlpt of `Unknown`
+    const empty =
+        dictLookup.kanji.length === 0 &&
+        dictLookup.jmentries.length === 0 &&
+        dictLookup.jmnentries.length === 0 &&
+        dictLookup.meanings.length === 0 &&
+        dictLookup.examples.length === 0 &&
+        dictLookup.jlpt === "Unknown";
+    if (!empty) {
+        return dictLookup;
+    } else {
+        return null;
+    }
+}
+
+/**
+ * Filters empty placeholders from a `DictWildcardLookup` response object
+ * and returns `null` in case the response object is considered empty
+ *
+ * @param {DictWildcardLookup} dictWildcardLookup The DictWildcardLookup object
+ * @returns {DictLookup | null} The filtered object or null
+ */
+export function filterDictWildcardLookup(
+    dictLookup: DictWildcardLookup | null
+): DictWildcardLookup | null {
+    // Filter Empty Elements
+    if (dictLookup) {
+        // Empty element has stroke count of `99`
+        dictLookup.kanji = dictLookup.kanji.filter(
+            (k) => k.stroke_count !== 99
+        );
+        // Empty element has no `kana` and no `kanji` and one sense with order of `99`
+        dictLookup.jmentries = dictLookup.jmentries.filter(
+            (jme) =>
+                (jme.kanji.length !== 0 || jme.kana.length !== 0) &&
+                jme.senses.length !== 0 &&
+                jme.senses[0].order !== 99
+        );
+        // Empty element has no `kana`, `kanji` or `gloss` and empty string as translation type
+        dictLookup.jmnentries = dictLookup.jmnentries.filter(
+            (jmne) =>
+                (jmne.kanji.length !== 0 || jmne.kana.length !== 0) &&
+                jmne.gloss.length !== 0 &&
+                jmne.translation_type !== ""
+        );
+    } else {
+        return null;
+    }
+    // Empty response has empty lists and jlpt of `Unknown`
+    const empty =
+        dictLookup.kanji.length === 0 &&
+        dictLookup.jmentries.length === 0 &&
+        dictLookup.jmnentries.length === 0 &&
+        dictLookup.examples.length === 0;
+    if (!empty) {
+        return dictLookup;
+    } else {
+        return null;
+    }
 }

--- a/apps/frontend/src/types/types.ts
+++ b/apps/frontend/src/types/types.ts
@@ -215,6 +215,18 @@ export interface DictLookup {
     examples: string[];
 }
 
+/**
+ * The shape of all the information from a wildcard dictionary lookup as
+ * returned by the API endpoint
+ */
+export interface DictWildcardLookup {
+    pattern: string;
+    jmentries: JMEntry[];
+    jmnentries: JMNEntry[];
+    kanji: KanjiInfo[];
+    examples: string[];
+}
+
 /*TranscribePage*/
 
 /**


### PR DESCRIPTION
## Description

### Additions

> Add a `Dictionary Page` allowing for wildcard lookups and complete display of API information

### Improvements

> Switch to querying the API with the `lemma` form of subtitle token so that tokens like `言わ` get searched as `言う`

## Issue

> **Related Issue** &rarr; None

## Type of Change

> -   [ ] **Bug Fix**

> -   [x] **New feature**

> -   [ ] **Documentation Update**

## Checklist

> -   [x] **I have performed a self-review of my code**

> -   [x] **I have commented my code**

> -   [x] **My changes don't break existing functionality**

## Additional Context

> **Additional information**
