### PR TITLE
V35

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -8,8 +8,8 @@ Security fixes are applied to the latest `3.x` release line
 
 | Version  | Supported          |
 | -------- | ------------------ |
-| `3.4.x`  | :white_check_mark: |
-| `< 3.4.0`  | :x:                |
+| `3.5.x`  | :white_check_mark: |
+| `< 3.5.0`  | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/apps/frontend/nginx/nginx.conf
+++ b/apps/frontend/nginx/nginx.conf
@@ -30,10 +30,21 @@ server {
     ssl_certificate_key /etc/nginx/ssl/server.key;
     ssl_protocols TLSv1.2 TLSv1.3;
 
-    # Serve static files
+    # Serve static files. The app shell (index.html, served for `/` and every
+    # client-side route through the fallback) plus the root service worker and
+    # manifest must revalidate on each load, so a new deploy is picked up rather
+    # than served from a stale cache. Hashed /assets/ files are content-addressed
+    # and safe to cache forever.
     location / {
         root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache";
         try_files $uri $uri/ /index.html;
+    }
+
+    location /assets/ {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+        try_files $uri =404;
     }
 
     # The local CA, downloadable for the one-time per-device install that

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.4.0",
+    "version": "3.5.0",
     "private": true,
     "type": "module",
     "engines": {

--- a/apps/frontend/src/features/profile/components/AdvancedPanel.tsx
+++ b/apps/frontend/src/features/profile/components/AdvancedPanel.tsx
@@ -15,8 +15,9 @@ import {
 } from "@/contexts/OperationSettingsContext";
 import { Button, Card, InfoTip, Input, Label, Segmented, TextArea, Toggle } from "@/shared/ui";
 import type { ConvertOpts, TranscribeOpts } from "@/shared/jobs/types";
+import { AppDataPanel } from "./AppDataPanel";
 
-type SubTab = "transcription" | "conversion";
+type SubTab = "transcription" | "conversion" | "app-data";
 
 // Hides the native number-input spin buttons (the white up/down arrows).
 const SPINNER_OFF =
@@ -138,6 +139,7 @@ export function AdvancedPanel() {
                 options={[
                     { value: "transcription", label: "Transcription" },
                     { value: "conversion", label: "Conversion" },
+                    { value: "app-data", label: "App Data" },
                 ]}
                 value={subTab}
                 onChange={setSubTab}
@@ -260,7 +262,7 @@ export function AdvancedPanel() {
                         />
                     </div>
                 </>
-            ) : (
+            ) : subTab === "conversion" ? (
                 <>
                     <p className="text-sm text-ink-muted">MP4 Conversion Output Settings</p>
                     <div>
@@ -301,16 +303,20 @@ export function AdvancedPanel() {
                         </div>
                     </div>
                 </>
+            ) : (
+                <AppDataPanel />
             )}
 
-            <div className="flex gap-2 border-t border-ink/10 pt-4">
-                <Button onClick={onSave} disabled={!dirty}>
-                    Save
-                </Button>
-                <Button variant="secondary" onClick={onReset}>
-                    Reset<span className="hidden sm:inline">{" To Default"}</span>
-                </Button>
-            </div>
+            {subTab !== "app-data" && (
+                <div className="flex gap-2 border-t border-ink/10 pt-4">
+                    <Button onClick={onSave} disabled={!dirty}>
+                        Save
+                    </Button>
+                    <Button variant="secondary" onClick={onReset}>
+                        Reset<span className="hidden sm:inline">{" To Default"}</span>
+                    </Button>
+                </div>
+            )}
         </Card>
     );
 }

--- a/apps/frontend/src/features/profile/components/AppDataPanel.tsx
+++ b/apps/frontend/src/features/profile/components/AppDataPanel.tsx
@@ -1,0 +1,43 @@
+/**
+ * @packageDocumentation The Advanced panel's App Data sub-tab: a maintenance
+ * action that unregisters the service worker and clears its caches, for
+ * recovering a client stuck on a stale cached build. Profile and preferences
+ * are kept.
+ */
+
+import { useState } from "react";
+import { Button } from "@/shared/ui";
+import { resetAppData } from "@/shared/pwa/reset";
+
+/** The App Data reset controls, rendered inside the Advanced panel. */
+export function AppDataPanel() {
+    const [confirming, setConfirming] = useState(false);
+
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-ink-muted">
+                Clears The Cached App And Reloads A Fresh Copy. Use This If An Update Has Not Taken
+                Effect. Your Profile And Settings Are Kept
+            </p>
+            <div className="flex items-center justify-center gap-2">
+                <Button
+                    variant="secondary"
+                    onClick={() => {
+                        if (confirming) {
+                            void resetAppData();
+                        } else {
+                            setConfirming(true);
+                        }
+                    }}
+                >
+                    {confirming ? "Tap Again To Confirm" : "Reset App Data"}
+                </Button>
+                {confirming && (
+                    <Button variant="ghost" onClick={() => setConfirming(false)}>
+                        Cancel
+                    </Button>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/frontend/src/main.tsx
+++ b/apps/frontend/src/main.tsx
@@ -64,6 +64,9 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         </SWRConfig>
         <Toaster
             position="top-center"
+            // Clear the notch on standalone iOS PWAs (viewport-fit=cover +
+            // black-translucent status bar draw under it). --sat is 0 off-notch.
+            containerStyle={{ top: "calc(var(--sat) + 1rem)" }}
             toastOptions={{
                 duration: 4000,
                 // "Sumi & Shu" surface + hairline + washi ink, so toasts blend

--- a/apps/frontend/src/shared/components/VideoControls.tsx
+++ b/apps/frontend/src/shared/components/VideoControls.tsx
@@ -10,8 +10,14 @@ import { useEffect, useState } from "react";
 import { Play, Pause, Volume2, VolumeX } from "lucide-react";
 import { formatClock } from "@/shared/format/time";
 import { cn } from "@/shared/ui";
+import { isIOS } from "@/shared/platform";
 
 const RATES = [0.5, 0.75, 1, 1.25, 1.5, 2];
+
+// iOS Safari makes HTMLMediaElement.volume read-only (hardware buttons own it),
+// so the volume slider is a dead control there. Hide it and keep the mute
+// toggle, which video.muted still honors. Constant per session, so read once.
+const IS_IOS = isIOS();
 
 export interface VideoControlsProps {
     video: HTMLVideoElement | null;
@@ -123,22 +129,24 @@ export function VideoControls({ video, visible }: VideoControlsProps) {
                     >
                         {muted || volume === 0 ? <VolumeX size={18} /> : <Volume2 size={18} />}
                     </button>
-                    <input
-                        type="range"
-                        min={0}
-                        max={1}
-                        step="0.05"
-                        value={muted ? 0 : volume}
-                        onChange={(e) => {
-                            video.muted = false;
-                            video.volume = Number(e.target.value);
-                        }}
-                        aria-label="Volume"
-                        className={cn(rangeBase, "w-20")}
-                        style={{
-                            background: `linear-gradient(to right, rgb(var(--ink)) ${volPct}%, rgb(var(--ink) / 0.25) ${volPct}%)`,
-                        }}
-                    />
+                    {!IS_IOS && (
+                        <input
+                            type="range"
+                            min={0}
+                            max={1}
+                            step="0.05"
+                            value={muted ? 0 : volume}
+                            onChange={(e) => {
+                                video.muted = false;
+                                video.volume = Number(e.target.value);
+                            }}
+                            aria-label="Volume"
+                            className={cn(rangeBase, "w-20")}
+                            style={{
+                                background: `linear-gradient(to right, rgb(var(--ink)) ${volPct}%, rgb(var(--ink) / 0.25) ${volPct}%)`,
+                            }}
+                        />
+                    )}
 
                     <span className="text-xs tabular-nums text-ink-muted">
                         {formatClock(current)} / {formatClock(duration)}

--- a/apps/frontend/src/shared/platform.ts
+++ b/apps/frontend/src/shared/platform.ts
@@ -1,0 +1,18 @@
+/**
+ * @packageDocumentation Platform detection for the few places that must branch
+ * on the host OS rather than the viewport. The viewport-based checks live in
+ * shared/hooks/useMediaQuery.
+ */
+
+/**
+ * Detects iOS (iPhone, iPad, iPod), including iPadOS 13+, which reports a
+ * desktop Safari user agent and is only distinguishable by touch support.
+ *
+ * @returns {boolean} True on an iOS or iPadOS device.
+ */
+export function isIOS(): boolean {
+    if (typeof navigator === "undefined") return false;
+    const legacy = /iPad|iPhone|iPod/.test(navigator.userAgent);
+    const iPadOS13 = navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1;
+    return legacy || iPadOS13;
+}

--- a/apps/frontend/src/shared/pwa/reset.ts
+++ b/apps/frontend/src/shared/pwa/reset.ts
@@ -1,0 +1,24 @@
+/**
+ * @packageDocumentation Clears the installed service worker and its caches, the
+ * escape hatch for a client stuck on a stale cached build.
+ */
+
+/**
+ * Unregisters every service worker for this origin, deletes every Cache Storage
+ * bucket, then reloads so the next load fetches a fresh index and assets.
+ * Leaves localStorage intact so the profile and preferences survive.
+ *
+ * @returns {Promise<void>} Resolves after the caches are cleared, just before
+ *   the reload.
+ */
+export async function resetAppData(): Promise<void> {
+    if ("serviceWorker" in navigator) {
+        const registrations = await navigator.serviceWorker.getRegistrations();
+        await Promise.all(registrations.map((r) => r.unregister()));
+    }
+    if ("caches" in window) {
+        const keys = await caches.keys();
+        await Promise.all(keys.map((k) => caches.delete(k)));
+    }
+    window.location.reload();
+}

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -25,71 +25,86 @@ function demoAssets(): Plugin {
     };
 }
 
-// The service worker is disabled in demo mode: its `/api` NetworkOnly rule and
-// navigation-fallback denylist are written for the root `/api`, not the
-// base-prefixed `/mirumoji/api`, and offline is not a demo goal.
-const pwa = VitePWA({
-    // Auto-update the service worker in the background -> no "reload?" prompt
-    registerType: "autoUpdate",
-    // public/ assets that should be precached alongside the build output
-    includeAssets: ["favicon.ico", "icons/icon-192.png", "icons/icon-512.png"],
-    // scope / start_url are left to the plugin so they track Vite's `base`
-    // (`/` self-hosted, `/mirumoji/` on Pages). Icon/screenshot srcs are
-    // relative so they resolve against the manifest URL under either base
-    manifest: {
-        name: "Mirumoji",
-        short_name: "Mirumoji",
-        description: "Japanese Immersion Toolkit",
-        theme_color: "#15120F",
-        background_color: "#15120F",
-        display: "standalone",
-        icons: [
-            { src: "icons/icon-192.png", sizes: "192x192", type: "image/png", purpose: "any" },
-            { src: "icons/icon-512.png", sizes: "512x512", type: "image/png", purpose: "any" },
-            {
-                src: "icons/icon-512.png",
-                sizes: "512x512",
-                type: "image/png",
-                purpose: "maskable",
-            },
-        ],
-        screenshots: [
-            {
-                src: "screenshots/desktop_screenshot.png",
-                sizes: "2869x1435",
-                type: "image/png",
-                form_factor: "wide",
-            },
-            {
-                src: "screenshots/mobile_screenshot.png",
-                sizes: "1290x2796",
-                type: "image/png",
-            },
-        ],
-    },
-    workbox: {
-        // Keep the SPA navigation fallback from swallowing requests for
-        // paths nginx serves directly: API calls, the mkdocs site under
-        // /docs on the Pages build, and the local CA download. Without
-        // the CA entry, navigating to /mirumoji-ca.crt on the HTTPS
-        // origin (where the service worker runs) falls back to
-        // index.html and lands on the app's 404, while plain HTTP works
-        // because no service worker runs on an insecure origin. The
-        // /docs match allows a missing trailing slash (/docs and /docs/)
-        navigateFallbackDenylist: [/^\/api\//, /\/docs(?:\/|$)/, /^\/mirumoji-ca\.crt$/],
-        runtimeCaching: [
-            {
-                urlPattern: ({ url }) => url.pathname.startsWith("/api/"),
-                handler: "NetworkOnly",
-            },
-        ],
-    },
-});
+/**
+ * The PWA plugin, enabled in both the real and demo builds so the demo is
+ * installable too. useCredentials makes the manifest and icon fetches carry
+ * credentials, which the Modal host Basic Auth requires and same-origin deploys
+ * ignore. The /api matchers are base-agnostic so they hold under the root / and
+ * the Pages /mirumoji/ base.
+ */
+function makePwa(demo: boolean): Plugin[] {
+    return VitePWA({
+        // Auto-update the service worker in the background -> no "reload?" prompt
+        registerType: "autoUpdate",
+        // Send credentials with the manifest + icon fetches so they pass the
+        // Modal host Basic Auth (harmless same-origin on nginx / Pages)
+        useCredentials: true,
+        // public/ assets that should be precached alongside the build output
+        includeAssets: ["favicon.ico", "icons/icon-192.png", "icons/icon-512.png"],
+        // scope / start_url are left to the plugin so they track Vite's `base`
+        // (`/` self-hosted, `/mirumoji/` on Pages). Icon/screenshot srcs are
+        // relative so they resolve against the manifest URL under either base
+        manifest: {
+            name: "Mirumoji",
+            short_name: "Mirumoji",
+            description: "Japanese Immersion Toolkit",
+            theme_color: "#15120F",
+            background_color: "#15120F",
+            display: "standalone",
+            icons: [
+                { src: "icons/icon-192.png", sizes: "192x192", type: "image/png", purpose: "any" },
+                { src: "icons/icon-512.png", sizes: "512x512", type: "image/png", purpose: "any" },
+                {
+                    src: "icons/icon-512.png",
+                    sizes: "512x512",
+                    type: "image/png",
+                    purpose: "maskable",
+                },
+            ],
+            screenshots: [
+                {
+                    src: "screenshots/desktop_screenshot.png",
+                    sizes: "2869x1435",
+                    type: "image/png",
+                    form_factor: "wide",
+                },
+                {
+                    src: "screenshots/mobile_screenshot.png",
+                    sizes: "1290x2796",
+                    type: "image/png",
+                },
+            ],
+        },
+        workbox: {
+            // Never precache the demo's static /api/* fixtures. The sample mp4
+            // exceeds the precache size cap anyway, and they are runtime-cached
+            // below.
+            globIgnores: demo ? ["api/**"] : [],
+            // Keep the SPA navigation fallback from swallowing requests for paths
+            // served directly: API calls, the mkdocs site under /docs on the
+            // Pages build, and the local CA download. The /api and /docs matchers
+            // are unanchored so they also hold under the /mirumoji/ base.
+            navigateFallbackDenylist: [/\/api\//, /\/docs(?:\/|$)/, /^\/mirumoji-ca\.crt$/],
+            runtimeCaching: [
+                {
+                    // Base-agnostic: matches /api/ and /mirumoji/api/
+                    urlPattern: ({ url }) => url.pathname.includes("/api/"),
+                    // The demo /api/* are committed static fixtures, so cache
+                    // them. The real app /api is a live backend, never cached.
+                    handler: demo ? "CacheFirst" : "NetworkOnly",
+                },
+            ],
+        },
+    });
+}
 
 export default defineConfig(({ mode }) => {
     const demo = mode === "demo";
     return {
-        plugins: [react(), ...(demo ? [demoAssets()] : [pwa])],
+        // The PWA plugin runs before demoAssets so the service worker is
+        // generated before the demo /api fixtures are copied into dist, keeping
+        // them out of the precache manifest.
+        plugins: [react(), makePwa(demo), ...(demo ? [demoAssets()] : [])],
         resolve: {
             // In demo mode, the network layer and a few components are swapped
             // for fixture-backed variants under src/demo/. The `@real/*` channel

--- a/apps/mirumoji/pyproject.toml
+++ b/apps/mirumoji/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mirumoji"
-version = "3.4.0"
+version = "3.5.0"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "Self-Hostable Japanese Language Immersion Tool"

--- a/apps/mirumoji/src/mirumoji/__init__.py
+++ b/apps/mirumoji/src/mirumoji/__init__.py
@@ -7,4 +7,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("mirumoji")
 except PackageNotFoundError:
-    __version__ = "3.4.0"
+    __version__ = "3.5.0"

--- a/apps/mirumoji/src/mirumoji/launcher/cli/_common.py
+++ b/apps/mirumoji/src/mirumoji/launcher/cli/_common.py
@@ -598,6 +598,26 @@ def require_env(backend: Backend, env_path: Path) -> None:
         )
 
 
+def require_published_version(version: str) -> None:
+    """
+    Aborts a CLI command when a pinned `version` has no published images
+
+    A thin wrapper over `checks.require_published_version` that maps its
+    `DependencyError` to a clean `Typer` exit
+
+    Args:
+        version (str): The resolved image version
+
+    Raises:
+        typer.Exit: If the version has no published images or Docker Hub could
+            not be reached
+    """
+    try:
+        checks.require_published_version(version)
+    except LauncherError as exc:
+        raise fail(str(exc)) from exc
+
+
 def resolve_managed_config(env_path: Path) -> dict[str, str]:
     """
     Resolves the managed config, overlaying it with the process' environment

--- a/apps/mirumoji/src/mirumoji/launcher/cli/commands.py
+++ b/apps/mirumoji/src/mirumoji/launcher/cli/commands.py
@@ -19,6 +19,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 
+from ... import __version__
 from ... import modal as modal_lifecycle
 from ...exceptions import ModalError
 from ...paths import HOST_CONFIG_FILE
@@ -48,6 +49,7 @@ from ._common import (
     _validate_dependencies,
     fail,
     require_env,
+    require_published_version,
     resolve_backend,
     resolve_managed_config,
     resolve_source,
@@ -238,6 +240,13 @@ def pull(
             help="Transcription Backend (Defaults To The Saved Config)",
         ),
     ] = None,
+    version: Annotated[
+        str | None,
+        typer.Option(
+            "--version",
+            help="Use This Published Version (Defaults To The Installed One)",
+        ),
+    ] = None,
 ) -> None:
     """
     Pulls the Mirumoji images from Docker Hub
@@ -253,9 +262,22 @@ def pull(
         - Value Stored in Config, If Present
 
         - Default Value (`MODAL`)
+
+    info: Version Resolution Order
+        The version value is resolved in the following order
+
+        - Value Passed To --version, If Present
+
+        - MIRUMOJI_VERSION Stored In Config, If Present
+
+        - Shell's MIRUMOJI_VERSION Environment Variable, If Present
+
+        - Default Value (The Installed Package Version)
     """
     backend = resolve_backend(transcribe, HOST_CONFIG_FILE)
-    compose_file = write_compose(backend, ImageSource.PULL)
+    version = envfile.resolve_version(HOST_CONFIG_FILE, version)
+    require_published_version(version)
+    compose_file = write_compose(backend, ImageSource.PULL, version=version)
     stream_command(
         gen=lifecycle.pull(compose_file),
         identifier="Docker",
@@ -299,6 +321,13 @@ def render(
             help="Reference Local Build Tags (--build) Or Docker Hub (--pull)",
         ),
     ] = False,
+    version: Annotated[
+        str,
+        typer.Option(
+            "--version",
+            help="Pin The Image Version (Defaults To The Installed One)",
+        ),
+    ] = __version__,
     output: Annotated[
         Path,
         typer.Option(
@@ -317,7 +346,9 @@ def render(
     """
     source = ImageSource.BUILD if build else ImageSource.PULL
     try:
-        written = write_compose(transcribe, source, out_path=output)
+        written = write_compose(
+            transcribe, source, version=version, out_path=output
+        )
     except FileNotFoundError as exc:
         raise fail(f"Compose Template Not Found  ↦  {exc}") from exc
     console.print(
@@ -472,6 +503,13 @@ def up(
             help="Run Detached (--detach) Or In The Foreground",
         ),
     ] = True,
+    version: Annotated[
+        str | None,
+        typer.Option(
+            "--version",
+            help="Use This Published Version (Defaults To The Installed One)",
+        ),
+    ] = None,
 ) -> None:
     """
     Launches the Mirumoji Docker Compose Application
@@ -498,6 +536,17 @@ def up(
 
         - Default Value (`PULL`)
 
+    info: Version Resolution Order
+        The version value is resolved in the following order
+
+        - Value Passed To --version, If Present
+
+        - MIRUMOJI_VERSION Stored In Config, If Present
+
+        - Shell's MIRUMOJI_VERSION Environment Variable, If Present
+
+        - Default Value (The Installed Package Version)
+
     info: Steps
         - Resolves the backend / image source according to the order of
           precedence listed above
@@ -520,9 +569,12 @@ def up(
 
     backend = resolve_backend(transcribe, HOST_CONFIG_FILE)
     source = resolve_source(build, HOST_CONFIG_FILE)
+    version = envfile.resolve_version(HOST_CONFIG_FILE, version)
 
     _validate_dependencies(backend, source)
     require_env(backend, HOST_CONFIG_FILE)
+    if source is ImageSource.PULL:
+        require_published_version(version)
 
     ip = host.get_host_lan_ip()
     os.environ[HOST_LAN_IP_VAR] = ip
@@ -548,7 +600,7 @@ def up(
 
         console.print("✓ Images Built", style="success")
 
-    compose_file = write_compose(backend, source)
+    compose_file = write_compose(backend, source, version=version)
 
     # No explicit pull here. `docker compose up` already pulls any missing
     # image and reuses cached ones, so a normal `up` doesn't need to hit
@@ -841,7 +893,8 @@ def dev_up(
 
     console.print("✓ Images Built", style="success")
 
-    compose_file = write_compose(backend, source)
+    # BUILD uses the fixed local image tags, so the version is irrelevant here
+    compose_file = write_compose(backend, source, version=__version__)
 
     stream_command(
         gen=lifecycle.up(
@@ -935,6 +988,13 @@ def modal_deploy(
             help="Redeploy Even If The Same Version Is Already Live",
         ),
     ] = False,
+    version: Annotated[
+        str | None,
+        typer.Option(
+            "--version",
+            help="Use This Published Version (Defaults To The Installed One)",
+        ),
+    ] = None,
 ) -> None:
     """
     Deploys A Fully Functional Mirumoji App To Your Modal Account
@@ -968,6 +1028,17 @@ def modal_deploy(
           without ever creating duplicates
 
         - Pass `--force` (`-f`) to always redeploy the app
+
+    info: Version Resolution Order
+        The version value is resolved in the following order
+
+        - Value Passed To --version, If Present
+
+        - MIRUMOJI_VERSION Stored In Config, If Present
+
+        - Shell's MIRUMOJI_VERSION Environment Variable, If Present
+
+        - Default Value (The Installed Package Version)
 
     info: Distinction From The Mirumoji `modal-offload` App
         - When running mirumoji locally with the `modal` transcribe backend
@@ -1059,6 +1130,9 @@ def modal_deploy(
         if var.default
     }
 
+    version = envfile.resolve_version(HOST_CONFIG_FILE, version)
+    require_published_version(version)
+
     # The Modal Credentials Are Exported Only For The Deploy Calls, Then The
     # Process Environment Is Restored
     with modal_lifecycle.modal_credentials(env):
@@ -1068,7 +1142,9 @@ def modal_deploy(
                 spinner="dots",
                 spinner_style="accent",
             ):
-                modal_host.ensure_host_deployed(env, host_config, force=force)
+                modal_host.ensure_host_deployed(
+                    env, host_config, version=version, force=force
+                )
         except ModalError as exc:
             raise fail(f"Failed To Deploy The App  ↦  {exc}") from exc
 

--- a/apps/mirumoji/src/mirumoji/launcher/cli/main.py
+++ b/apps/mirumoji/src/mirumoji/launcher/cli/main.py
@@ -4,8 +4,11 @@ Defines the `Mirumoji` CLI application built with `Typer` and `Rich`
 This is the single entry point for the package (`mirumoji`)
 """
 
+from typing import Annotated
+
 import typer
 
+from ... import __version__
 from ...log import setup_logging
 from .commands import (
     build,
@@ -40,14 +43,40 @@ app = typer.Typer(
 )
 
 
+def _version_callback(value: bool) -> None:
+    """
+    Prints the installed package version and exits when `--version` is passed
+
+    Args:
+        value (bool): Whether the `--version` flag was set
+    """
+    if value:
+        typer.echo(f"mirumoji {__version__}")
+        raise typer.Exit()
+
+
 @app.callback()
-def _configure() -> None:
+def _configure(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show The Installed Version And Exit",
+        ),
+    ] = False,
+) -> None:
     """
     Routes launcher logs to `launcher.log` before any command runs
 
     info: Console Off
         The console handler is disabled so diagnostic records never mix into a
         command's `Rich` output, which is the launcher's user-facing surface
+
+    Args:
+        version (bool): Print the version and exit (handled eagerly by the
+            callback before any command runs)
     """
     setup_logging(log_file="launcher.log", console=False)
 

--- a/apps/mirumoji/src/mirumoji/launcher/core/checks.py
+++ b/apps/mirumoji/src/mirumoji/launcher/core/checks.py
@@ -13,8 +13,11 @@ full report
 import logging
 import platform
 import shutil
+import urllib.error
+import urllib.request
 from importlib.util import find_spec
 
+from ... import __version__
 from . import process
 from .constants import _GPU_PROBE_IMAGE
 from .errors import DependencyError
@@ -285,3 +288,71 @@ def validate_deploy(
         results.append(nvidia_gpu())
         results.append(nvidia_toolkit())
     return results
+
+
+_DOCKERHUB_TAGS_URL = (
+    "https://hub.docker.com/v2/repositories/svdc1/mirumoji/tags/{tag}"
+)
+"""
+Template for the Docker Hub tags API endpoint, formatted with a `{tag}` to
+check whether a published image tag exists
+"""
+
+
+def version_published(version: str, *, timeout: float = 10.0) -> bool:
+    """
+    Reports whether the published Mirumoji images exist for a `version`
+
+    Queries the Docker Hub tags API for `frontend-{version}`. Every image
+    (frontend, backend, offload) is published together per release, so the
+    frontend tag is a reliable proxy for the whole set
+
+    Args:
+        version (str): The image version to check
+        timeout (float): The request timeout in seconds
+
+    Returns:
+        `True` when the tag exists, `False` on a 404
+
+    Raises:
+        DependencyError: If Docker Hub could not be reached
+    """
+    url = _DOCKERHUB_TAGS_URL.format(tag=f"frontend-{version}")
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:
+            status: int = response.status
+            return status == 200
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return False
+        raise DependencyError(
+            f"Could Not Verify Version {version} On Docker Hub  ↦  {exc}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise DependencyError(
+            f"Could Not Reach Docker Hub To Verify Version {version}  ↦  "
+            f"{exc.reason}"
+        ) from exc
+
+
+def require_published_version(version: str) -> None:
+    """
+    Raises when a pinned `version` has no published Mirumoji images
+
+    Skips the installed package version, which a release always publishes, so
+    only an explicitly pinned custom version pays the Docker Hub round-trip
+
+    Args:
+        version (str): The resolved image version
+
+    Raises:
+        DependencyError: If the version has no published images, or Docker Hub
+            could not be reached
+    """
+    if version == __version__:
+        return
+    if not version_published(version):
+        raise DependencyError(
+            f"Version {version} Has No Published Images  ↦  See The Available "
+            "Tags At https://hub.docker.com/r/svdc1/mirumoji/tags"
+        )

--- a/apps/mirumoji/src/mirumoji/launcher/core/compose.py
+++ b/apps/mirumoji/src/mirumoji/launcher/core/compose.py
@@ -69,14 +69,16 @@ Transcription Backend To Store The Faster Whisper Model Weights
 """
 
 
-def _backend_image(backend: Backend, source: ImageSource) -> str:
+def _backend_image(backend: Backend, source: ImageSource, version: str) -> str:
     """
     Determines which backend image reference to use based on a `backend` +
-    `source` pair
+    `source` pair, filling the published tag from `version`
 
     Args:
         backend (Backend): The chosen transcription backend
         source (ImageSource): Pull vs local build
+        version (str): The published image version to pull (ignored for a local
+            build, which uses the fixed local tags)
 
     Returns:
         The image reference to set on the backend service
@@ -86,23 +88,26 @@ def _backend_image(backend: Backend, source: ImageSource) -> str:
             return BACKEND_GPU_LOCAL_IMAGE
         return BACKEND_CPU_LOCAL_IMAGE
     if backend is Backend.LOCAL:
-        return BACKEND_GPU_IMAGE
-    return BACKEND_CPU_IMAGE
+        return BACKEND_GPU_IMAGE.format(version=version)
+    return BACKEND_CPU_IMAGE.format(version=version)
 
 
-def _frontend_image(source: ImageSource) -> str:
+def _frontend_image(source: ImageSource, version: str) -> str:
     """
-    Determines which frontend image reference to use for a given image `source`
+    Determines which frontend image reference to use for a given image
+    `source`, filling the published tag from `version`
 
     Args:
         source (ImageSource): Pull vs local build
+        version (str): The published image version to pull (ignored for a local
+            build, which uses the fixed local tag)
 
     Returns:
         The image reference to set on the frontend service
     """
     if source is ImageSource.BUILD:
         return FRONTEND_LOCAL_IMAGE
-    return FRONTEND_IMAGE
+    return FRONTEND_IMAGE.format(version=version)
 
 
 def load_template() -> dict[str, Any]:
@@ -124,6 +129,7 @@ def transform(
     template: dict[str, Any],
     backend: Backend,
     source: ImageSource,
+    version: str,
 ) -> dict[str, Any]:
     """
     Edits the `template` returned by `load_template` in place according to the
@@ -140,17 +146,18 @@ def transform(
         template (dict[str, Any]): The parsed packaged compose template
         backend (Backend): The chosen transcription backend
         source (ImageSource): Pull vs local build
+        version (str): The published image version to pull
 
     Returns:
         The same template dict, now resolved
     """
     services: dict[str, Any] = template["services"]
     # Set Frontend Image Reference
-    services[FRONTEND_SERVICE]["image"] = _frontend_image(source)
+    services[FRONTEND_SERVICE]["image"] = _frontend_image(source, version)
 
     backend_svc: dict[str, Any] = services[BACKEND_SERVICE]
     # Set Backend Image Reference
-    backend_svc["image"] = _backend_image(backend, source)
+    backend_svc["image"] = _backend_image(backend, source, version)
 
     if backend is Backend.LOCAL:
         # Attatch GPU Capability
@@ -178,6 +185,7 @@ def write_compose(
     backend: Backend,
     source: ImageSource,
     *,
+    version: str,
     out_path: Path = RESOLVED_COMPOSE_PATH,
 ) -> Path:
     """
@@ -186,6 +194,7 @@ def write_compose(
     Args:
         backend (Backend): The chosen mirumoji transcription backend
         source (ImageSource): Pull vs local build
+        version (str): The published image version to pull
         out_path (Path): Where to write the resolved file
 
     Returns:
@@ -194,7 +203,7 @@ def write_compose(
     Raises:
         FileNotFoundError: If the packaged template is missing
     """
-    resolved = transform(load_template(), backend, source)
+    resolved = transform(load_template(), backend, source, version)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w", encoding="utf-8") as fh:
         yaml.safe_dump(

--- a/apps/mirumoji/src/mirumoji/launcher/core/constants.py
+++ b/apps/mirumoji/src/mirumoji/launcher/core/constants.py
@@ -43,19 +43,20 @@ Identifier for the backend service in the `Mirumoji` Docker Compose application
 
 # --- Docker Image References ---
 
-FRONTEND_IMAGE = "svdc1/mirumoji:frontend-latest"
+FRONTEND_IMAGE = "svdc1/mirumoji:frontend-{version}"
 """
-Docker Hub Identifier of the latest `Mirumoji` frontend image
+String template for a Docker Hub Identifier of the `Mirumoji`
+frontend image
 """
-BACKEND_CPU_IMAGE = "svdc1/mirumoji:backend-cpu-latest"
+BACKEND_CPU_IMAGE = "svdc1/mirumoji:backend-cpu-{version}"
 """
-Docker Hub Identifier of the latest `Mirumoji` backend image for the `modal`
-transcription backend
+String template for a Docker Hub Identifier of the `Mirumoji` backend image for
+the `modal` transcription backend
 """
-BACKEND_GPU_IMAGE = "svdc1/mirumoji:backend-gpu-latest"
+BACKEND_GPU_IMAGE = "svdc1/mirumoji:backend-gpu-{version}"
 """
-Docker Hub Identifier of the latest `Mirumoji` backend image for the `local`
-transcription backend
+String template for Docker Hub Identifier of the `Mirumoji` backend image
+for the `local` transcription backend
 """
 
 # Tags Assigned To Images Built Locally
@@ -295,6 +296,15 @@ Launcher-Only. The compose template never references it, and the server
 ignores it
 """
 
+VERSION_VAR = "MIRUMOJI_VERSION"
+"""
+Pins the published image version the launcher pulls (and composes the Modal
+host from), defaulting to the installed package version
+
+Launcher-Only. It fills the `{version}` in the image references above and is
+never passed to the server or a container
+"""
+
 
 # --- Managed Config Surface ---
 
@@ -318,7 +328,9 @@ _DEPLOYMENT_CHOICES: dict[str, tuple[str, ...]] = {
 }
 
 CONFIG_KEYS: frozenset[str] = frozenset(
-    [v.name for v in CONFIG_ENV_VARS] + list(_DEPLOYMENT_CHOICES)
+    [v.name for v in CONFIG_ENV_VARS]
+    + list(_DEPLOYMENT_CHOICES)
+    + [VERSION_VAR]
 )
 """
 Every environment variable key that the launcher accepts in the managed config

--- a/apps/mirumoji/src/mirumoji/launcher/core/envfile.py
+++ b/apps/mirumoji/src/mirumoji/launcher/core/envfile.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 from dotenv import dotenv_values
 
-from .constants import IMAGE_SOURCE_VAR, TRANSCRIBE_BACKEND_VAR
+from ... import __version__
+from .constants import IMAGE_SOURCE_VAR, TRANSCRIBE_BACKEND_VAR, VERSION_VAR
 from .errors import EnvConfigError
 from .models import Backend, EnvVar, ImageSource
 
@@ -228,3 +229,30 @@ def read_deployment(
     backend = Backend(raw_backend) if raw_backend in _BACKEND_VALUES else None
     source = ImageSource(raw_source) if raw_source in _SOURCE_VALUES else None
     return backend, source
+
+
+def resolve_version(env_path: Path, flag: str | None = None) -> str:
+    """
+    Resolves the published image version the launcher pulls and composes with
+
+    info: Order of Precedence
+        The value is considered in the following order
+
+        - The `flag` passed to a command (`--version`)
+
+        - The persisted `MIRUMOJI_VERSION`, overlaid with the process
+          environment
+
+        - The installed package version
+
+    Args:
+        env_path (Path): The managed config file to read
+        flag (str | None): An explicit override (the CLI `--version`)
+
+    Returns:
+        The version that fills the `{version}` in the image references
+    """
+    if flag:
+        return flag
+    values = overlay_environ(read(env_path), [VERSION_VAR])
+    return values.get(VERSION_VAR) or __version__

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/dashboard.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/dashboard.py
@@ -12,8 +12,8 @@ from typing import TypeAlias, cast
 
 import flet as ft
 
+from ...core import checks, envfile, lifecycle, repo
 from ...core import compose as compose_core
-from ...core import envfile, lifecycle, repo
 from ...core.compose import RESOLVED_COMPOSE_PATH
 from ...core.constants import (
     CONFIG_ENV_VARS,
@@ -107,10 +107,15 @@ def _up_flow(state: AppState) -> Generator[str, None, str]:
     ip = get_host_lan_ip()
     os.environ[HOST_LAN_IP_VAR] = ip
     os.environ[TRANSCRIBE_BACKEND_VAR] = state.backend.value
+    version = envfile.resolve_version(state.env_path)
     if state.source is ImageSource.BUILD:
         repo_path = yield from repo.ensure_repo()
         yield from lifecycle.build_images(repo_path, state.backend)
-    compose_file = compose_core.write_compose(state.backend, state.source)
+    else:
+        checks.require_published_version(version)
+    compose_file = compose_core.write_compose(
+        state.backend, state.source, version=version
+    )
     if state.source is ImageSource.PULL:
         yield from lifecycle.pull(compose_file, env_file=state.env_path)
     yield from lifecycle.up(compose_file, env_file=state.env_path)
@@ -144,7 +149,11 @@ def _pull_flow(state: AppState) -> Generator[str, None, int]:
     Returns:
         The compose exit code
     """
-    compose_file = compose_core.write_compose(state.backend, ImageSource.PULL)
+    version = envfile.resolve_version(state.env_path)
+    checks.require_published_version(version)
+    compose_file = compose_core.write_compose(
+        state.backend, ImageSource.PULL, version=version
+    )
     return (yield from lifecycle.pull(compose_file, env_file=state.env_path))
 
 

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/modal_host.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/modal_host.py
@@ -14,7 +14,7 @@ import flet as ft
 
 from .... import modal as modal_lifecycle
 from ....exceptions import ModalError
-from ...core import envfile
+from ...core import checks, envfile
 from ...core.constants import (
     CONFIG_ENV_VARS,
     MODAL_HOST_VARS,
@@ -203,8 +203,12 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
             # loop startup. The `modal_lifecycle` helpers import it lazily too
             from ...modal import host as host_deploy
 
+            version = envfile.resolve_version(state.env_path)
+            checks.require_published_version(version)
             with modal_lifecycle.modal_credentials(env):
-                host_deploy.ensure_host_deployed(env, host_config)
+                host_deploy.ensure_host_deployed(
+                    env, host_config, version=version
+                )
                 return {
                     "url": modal_lifecycle.web_url(
                         HOST_APP_NAME, WEB_FUNCTION_NAME

--- a/apps/mirumoji/src/mirumoji/launcher/modal/app.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/app.py
@@ -47,6 +47,25 @@ def _is_within(root: Path, path: Path) -> bool:
         return False
 
 
+def _cache_control(full_path: str) -> str:
+    """
+    Chooses a Cache-Control value for a served frontend file
+
+    Content-hashed build assets under `assets/` never change and are cached
+    permanently, while the shell, service worker, and manifest revalidate so a
+    new deploy is picked up instead of a stale copy
+
+    Args:
+        full_path (str): The requested path below the app root
+
+    Returns:
+        The Cache-Control header value
+    """
+    if full_path.startswith("assets/"):
+        return "public, max-age=31536000, immutable"
+    return "no-cache"
+
+
 def create_host_app(frontend_dir: Path) -> FastAPI:
     """
     Builds the FastAPI application server by the `mirumoji-host` Modal app
@@ -176,8 +195,14 @@ def create_host_app(frontend_dir: Path) -> FastAPI:
             and candidate.is_file()
             and _is_within(frontend_dir, candidate)
         ):
-            return FileResponse(candidate)
-        return FileResponse(index_file)
+            return FileResponse(
+                candidate,
+                headers={"Cache-Control": _cache_control(full_path)},
+            )
+        return FileResponse(
+            index_file,
+            headers={"Cache-Control": "no-cache"},
+        )
 
     # CORS stays permissive to match the server (the host is single-origin, so
     # it is a no-op for the browser). Basic Auth is added last so it wraps

--- a/apps/mirumoji/src/mirumoji/launcher/modal/host.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/host.py
@@ -77,10 +77,10 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def _host_image() -> modal.Image:
+def _host_image(version: str) -> modal.Image:
     """
     Composes the `Modal` host's image from the published backend and frontend
-    images
+    images at `version`
 
     Starts from the CPU backend image (the server stack plus the UniDic and
     Kotobase data) and copies the already-published frontend build in, so the
@@ -91,12 +91,16 @@ def _host_image() -> modal.Image:
         (which platformdirs places under the state dir on Linux) land on the
         persistent volume rather than ephemeral container storage
 
+    Args:
+        version (str): The published image version to compose from
+
     Returns:
         The composed host image
     """
-    copy = f"COPY --from={FRONTEND_IMAGE} {FRONTEND_IMAGE_ROOT} {FRONTEND_DIR}"
+    frontend = FRONTEND_IMAGE.format(version=version)
+    copy = f"COPY --from={frontend} {FRONTEND_IMAGE_ROOT} {FRONTEND_DIR}"
     return (
-        modal.Image.from_registry(BACKEND_CPU_IMAGE)
+        modal.Image.from_registry(BACKEND_CPU_IMAGE.format(version=version))
         .dockerfile_commands(copy)
         .env({"XDG_STATE_HOME": STATE_MOUNT})
     )
@@ -127,6 +131,8 @@ def web() -> FastAPI:
 def build_host_app(
     env: dict[str, str],
     host_config: dict[str, str],
+    *,
+    version: str,
 ) -> modal.App:
     """
     Builds the deployable `Modal` host app with the user's config injected
@@ -175,6 +181,7 @@ def build_host_app(
         host_config (dict[str, str]): The resolved host reservations (CPU
             cores, memory in MiB, and max concurrent requests), each already
             defaulted by the caller, that size the web container
+        version (str): The published image version to compose from
 
     Returns:
         The configured `mirumoji-host` app with `web` registered
@@ -182,7 +189,7 @@ def build_host_app(
     Raises:
         ModalError: If a host reservation in `host_config` is not a number
     """
-    app = modal.App(HOST_APP_NAME, image=_host_image())
+    app = modal.App(HOST_APP_NAME, image=_host_image(version))
     volume = modal.Volume.from_name(DATA_VOLUME_NAME, create_if_missing=True)
     secret = modal.Secret.from_dict(dict(env))
 
@@ -210,6 +217,7 @@ def ensure_host_deployed(
     env: dict[str, str],
     host_config: dict[str, str],
     *,
+    version: str,
     force: bool = False,
 ) -> None:
     """
@@ -223,6 +231,7 @@ def ensure_host_deployed(
         env (dict[str, str]): The environment to inject into the container
         host_config (dict[str, str]): The resolved host reservations sizing the
             web container (see `build_host_app`)
+        version (str): The published image version to compose from
         force (bool): Redeploy even when the same version is already live, to
             roll out a code or image change without a version bump
 
@@ -231,7 +240,7 @@ def ensure_host_deployed(
     """
     ensure_volume(DATA_VOLUME_NAME)
     ensure_deployed(
-        build_host_app(env, host_config),
+        build_host_app(env, host_config, version=version),
         HOST_APP_NAME,
         version=__version__,
         force=force,

--- a/apps/mirumoji/src/mirumoji/modal.py
+++ b/apps/mirumoji/src/mirumoji/modal.py
@@ -140,6 +140,12 @@ _CREDENTIAL_KEYS = ("MODAL_TOKEN_ID", "MODAL_TOKEN_SECRET")
 The environment variables the `Modal` SDK and CLI authenticate from
 """
 
+_FORCE_BUILD_KEY = "MODAL_FORCE_BUILD"
+"""
+The environment variable the `Modal` SDK reads at deploy time to rebuild a
+cached image instead of reusing it
+"""
+
 
 @contextmanager
 def modal_credentials(env: dict[str, str]) -> Iterator[None]:
@@ -147,10 +153,14 @@ def modal_credentials(env: dict[str, str]) -> Iterator[None]:
     Exports the Modal credentials for the duration of a block, restoring the
     previous process environment on exit
 
-    info: Credentials Only
+    info: Exported Keys
         - The `Modal` SDK and the `modal` CLI subprocesses (`stop`, volume
           download) authenticate from `MODAL_TOKEN_ID` / `MODAL_TOKEN_SECRET`
-          in the environment, so only those are exported
+          in the environment, so those are exported
+
+        - `MODAL_FORCE_BUILD` is exported too, but only when explicitly
+          enabled, since the SDK reads it from the local process at
+          `app.deploy()` to rebuild a cached image instead of reusing it
 
         - The rest of the managed config reaches a deploy through the
           container's inline `Secret`, not the local process, so it never
@@ -170,10 +180,15 @@ def modal_credentials(env: dict[str, str]) -> Iterator[None]:
     Yields:
         None, with the credentials exported for the duration of the block
     """
-    saved = {key: os.environ.get(key) for key in _CREDENTIAL_KEYS}
+    keys = (*_CREDENTIAL_KEYS, _FORCE_BUILD_KEY)
+    saved = {key: os.environ.get(key) for key in keys}
     for key in _CREDENTIAL_KEYS:
         if env.get(key):
             os.environ[key] = env[key]
+    # Export MODAL_FORCE_BUILD only when set to "1", so the managed default
+    # "0" never forces a rebuild
+    if env.get(_FORCE_BUILD_KEY) == "1":
+        os.environ[_FORCE_BUILD_KEY] = "1"
     try:
         yield
     finally:

--- a/apps/mirumoji/src/mirumoji/server/config.py
+++ b/apps/mirumoji/src/mirumoji/server/config.py
@@ -20,6 +20,7 @@ from typing import Any, Literal
 
 from dotenv import load_dotenv
 
+from .. import __version__
 from ..exceptions import ModalError, WhisperUnavailableError
 from .constants import (
     DEFAULT_BREAKDOWN_SYS_MSG,
@@ -118,7 +119,7 @@ def get_settings() -> Settings:
         modal_gpu=os.environ.get("MIRUMOJI_MODAL_GPU", "A10G"),
         modal_image=os.environ.get(
             "MIRUMOJI_MODAL_IMAGE",
-            "docker.io/svdc1/mirumoji-modal-gpu:latest",
+            f"docker.io/svdc1/mirumoji-modal-gpu:{__version__}",
         ),
         modal_scaledown_window=_env_int(
             "MIRUMOJI_MODAL_SCALEDOWN_WINDOW",

--- a/docs/site/docs_md/project/changelog.md
+++ b/docs/site/docs_md/project/changelog.md
@@ -19,6 +19,61 @@ starting from **`v3.0.0`**
 
 ---
 
+## [`3.5.0`](https://github.com/svdC1/mirumoji/releases/tag/v3.5.0) - 2026-07-15
+
+This release makes the launcher run the container images that match the
+installed version instead of always pulling `latest`, so an install runs the
+images built for it and any published version can be pinned. It also makes the
+live demo installable as a PWA, adds an in-app cache reset, and fixes a set of
+mobile, caching, and Modal deploy issues. It has no breaking changes
+
+### Added
+
+- `Launcher` &rarr; From this release on, the launcher pulls and composes the
+  `<version>`-tagged images matching the installed package rather than `latest`,
+  so a `pip install mirumoji==X` (for `X >= 3.5.0`) runs the images built for `X`
+  and the launcher never drifts onto an incompatible `latest`. A `MIRUMOJI_VERSION`
+  config variable and a `--version` flag on `up` / `pull` / `render` /
+  `modal deploy` pin any published version, checked against Docker Hub first so a
+  version with no published images fails early with a clear message *(older,
+  pre-3.5.0 installs still pull `latest`, since the version-pinning code only
+  ships from here on)*
+
+- `Launcher` &rarr; `mirumoji --version` prints the installed version
+
+- `Frontend` &rarr; The live demo is now an installable PWA, so a visitor can add
+  it to their home screen and see how the app behaves once installed. The app
+  also gained a `Reset App Data` action *(Dashboard &rarr; Advanced)* that
+  unregisters the service worker and clears its caches, to recover from a stale
+  cached build
+
+### Fixed
+
+- `Launcher` &rarr; `MODAL_FORCE_BUILD` had no effect on `mirumoji modal deploy`.
+  The Modal SDK reads it from the local process environment when it builds the
+  derived host image, but the deploy exported only the Modal tokens, so setting
+  the variable never forced a rebuild and the host stayed on a stale cached image.
+  It is now exported for the deploy, so `mirumoji config set MODAL_FORCE_BUILD 1`
+  rebuilds the host image
+
+- `Frontend` &rarr; Toasts were rendered under the notch on notched phones. They
+  now inset off the safe area and clear it
+
+- `Frontend` &rarr; The player's volume slider did nothing on iOS, where the media
+  volume is read-only and owned by the hardware buttons, so it looked broken. It
+  is now hidden on iOS, leaving the mute toggle, which still works
+
+- `Frontend` &rarr; The PWA could not be installed behind the Modal host's HTTP
+  Basic Auth. The manifest link was fetched without credentials, so it and its
+  icons returned 401 and the browser saw no installable manifest, leaving no app
+  icon or install prompt. The manifest is now requested with credentials
+
+- `Frontend` &rarr; A new build could be hidden behind a stale cached shell.
+  Neither Nginx nor the Modal host set `Cache-Control`, so `index.html`, the
+  service worker, and the manifest could be served stale from the HTTP cache,
+  pinning old hashed assets. They are now served `no-cache` *(with hashed assets
+  marked immutable)*, so a new version is picked up on the next load
+
 ## [`3.4.0`](https://github.com/svdC1/mirumoji/releases/tag/v3.4.0) - 2026-07-14
 
 This release adds a one-command private full-host deploy to `Modal`, reworks the Modal GPU offload


### PR DESCRIPTION
## 3.5.0 Summary

A bug-fix + additions release (minor bump, no breaking changes)
resolving 7 issues of 3.4.0. It pins the launcher's container
images to the installed version, makes the live demo an installable PWA, adds an
in-app cache reset, and fixes a set of mobile, caching, and Modal deploy issues

## Frontend iOS + Toast fixes (ae76e6f)

- Toasts used react-hot-toast's default 16px top offset, so a notched iOS PWA
  drew them under the notch. The `<Toaster>` now insets off the shared `--sat`
  safe-area variable, which resolves to 0 off-notch

- iOS Safari makes `HTMLMediaElement.volume` read-only (the volume is owned by
  the hardware buttons, per Apple's docs), so the player's volume slider silently
  did nothing and looked broken. A new `isIOS()` helper (`shared/platform.ts`)
  hides the slider on iOS and keeps the mute toggle, which `video.muted` still
  honors. `VideoControls` is shared by the app and the demo, so one change covers
  both

## Installable Demo PWA + Cache Management (ac7b6a5)

- The demo build previously stripped the service worker. It now shares one
  `makePwa(demo)` factory with the production build, so a visitor can install the
  demo and see how the app behaves once installed

- `useCredentials: true` emits the manifest link with
  `crossorigin="use-credentials"`. Behind the Modal host's HTTP Basic Auth the
  manifest and its icons were fetched without credentials and returned 401, so
  there was no install prompt or app icon. They are now fetched with credentials

- The PWA's `/api` matchers are base-agnostic (`includes("/api/")`, unanchored
  denylist), so they hold under both `/` and the `/mirumoji/` Pages base. The
  demo caches its static `/api` fixtures (CacheFirst) rather than treating them
  as a live backend, and `globIgnores` keeps them out of the precache

- `index.html`, the service worker, and the manifest are served
  `Cache-Control: no-cache` (hashed `/assets/` immutable) on both Nginx and the
  Modal host, so a new deploy is picked up instead of a stale cached shell. On
  Nginx the header sits on `location /` so it also covers the `/` to index.html
  fallback that serves every client-side route

- A `Reset App Data` action (Dashboard, Advanced sub-tab) unregisters the service
  worker and clears its caches, an escape hatch for a client already stuck on a
  stale build

## Launcher Version Pinning + MODAL_FORCE_BUILD (e1a0e08)

- The launcher pulled and composed `:latest`, so a given install could run
  mismatched images and no specific version could be selected. The image
  references are now `{version}` templates filled with the installed package
  version by default, overridable per run with a `MIRUMOJI_VERSION` config
  variable or a `--version` flag on `up` / `pull` / `render` / `modal deploy`

- A pinned version is checked against the Docker Hub tags API before pulling or
  deploying, only when it differs from the installed version so the default path
  pays nothing, so a version with no published images fails early with a clear
  message instead of a raw registry pull error

- `mirumoji --version` prints the installed version, and the Modal offload image
  default now tracks the version too

- `MODAL_FORCE_BUILD` had no effect on `modal deploy`: the Modal SDK reads it from
  the local process environment when it builds the derived host image, but the
  deploy exported only the Modal tokens. It is now exported for the deploy, so
  setting it forces the host image to rebuild instead of reusing a cached layer

- This fixes the "run a specific version" problem forward-only. Pre-3.5.0
  installs still pull `latest`, since the version-pinning code only ships here on

## Release (1fc9b83)

- Version bumped to 3.5.0 (Python + frontend), changelog entry, and the
  security-policy supported table moved to 3.5.x. No breaking changes