### PR TITLE
V351

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.4.0",
+    "version": "3.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mirumoji-ui",
-            "version": "3.4.0",
+            "version": "3.5.1",
             "dependencies": {
                 "@fontsource/hanken-grotesk": "^5.2.8",
                 "@fontsource/newsreader": "^5.2.10",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.5.0",
+    "version": "3.5.1",
     "private": true,
     "type": "module",
     "engines": {

--- a/apps/frontend/src/shared/clips/recorder.ts
+++ b/apps/frontend/src/shared/clips/recorder.ts
@@ -4,11 +4,37 @@
  * to a canvas-based approach (iOS Safari). Also picks a supported MIME type.
  */
 
-// Single shared audio context (created lazily-ish at module load).
-const sharedAudioCtx = new (
-    window.AudioContext ||
-    (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
-)();
+// One shared AudioContext for the canvas-fallback recording path (iOS Safari).
+// Created lazily so it is born inside a user gesture rather than suspended at
+// page load, which a later recording cannot reliably resume.
+let sharedAudioCtx: AudioContext | null = null;
+
+function getAudioContext(): AudioContext {
+    if (!sharedAudioCtx) {
+        const Ctor =
+            window.AudioContext ||
+            (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext;
+        sharedAudioCtx = new Ctor();
+    }
+    return sharedAudioCtx;
+}
+
+/**
+ * Warms the recorder's AudioContext from within a user gesture.
+ *
+ * The canvas-fallback recording path (iOS Safari) draws its audio from this
+ * shared AudioContext, which only leaves the "suspended" state when resumed
+ * during a user activation. A save-clip flow can await a breakdown stream for
+ * several seconds before recording, by which point the click's activation is
+ * spent and the context can no longer resume. Call this synchronously from the
+ * click handler so the context is already running when recording starts.
+ */
+export function warmupRecorder(): void {
+    const ctx = getAudioContext();
+    if (ctx.state === "suspended") {
+        void ctx.resume();
+    }
+}
 
 // One MediaElementAudioSourceNode per <video> (a video may only ever connect to
 // a single source node for the page's lifetime).
@@ -45,14 +71,21 @@ export async function getStream(
         throw new Error("Could not create 2D canvas context.");
     }
 
-    let sourceNode = elementSourceMap.get(videoElement);
-    if (!sourceNode) {
-        sourceNode = sharedAudioCtx.createMediaElementSource(videoElement);
-        elementSourceMap.set(videoElement, sourceNode);
-        sourceNode.connect(sharedAudioCtx.destination);
+    const audioCtx = getAudioContext();
+    // The context may still be suspended if the gesture was never warmed; try
+    // to resume it here too so the audio track produces data.
+    if (audioCtx.state === "suspended") {
+        await audioCtx.resume();
     }
 
-    const destinationNode = sharedAudioCtx.createMediaStreamDestination();
+    let sourceNode = elementSourceMap.get(videoElement);
+    if (!sourceNode) {
+        sourceNode = audioCtx.createMediaElementSource(videoElement);
+        elementSourceMap.set(videoElement, sourceNode);
+        sourceNode.connect(audioCtx.destination);
+    }
+
+    const destinationNode = audioCtx.createMediaStreamDestination();
     sourceNode.connect(destinationNode);
 
     const videoTrack = canvas.captureStream(30).getVideoTracks()[0];
@@ -87,6 +120,16 @@ export function createRecordingPromise(
     recordingOptions: { mimeType: string; fileExtension: string }
 ): Promise<File> {
     return new Promise<File>((resolve, reject) => {
+        let settled = false;
+        const stopTracks = () => stream.getTracks().forEach((track) => track.stop());
+        // Settle exactly once. Guards against a late safety-timeout firing after
+        // a normal onstop, and against onstop never firing at all.
+        const finish = (run: () => void) => {
+            if (settled) return;
+            settled = true;
+            run();
+        };
+
         try {
             const recorder = new MediaRecorder(stream, { mimeType: recordingOptions.mimeType });
             const chunks: BlobPart[] = [];
@@ -96,30 +139,47 @@ export function createRecordingPromise(
             };
 
             recorder.onstop = () => {
-                stream.getTracks().forEach((track) => track.stop());
+                stopTracks();
                 if (chunks.length === 0) {
-                    return reject(new Error("No video data was recorded."));
+                    finish(() => reject(new Error("No video data was recorded.")));
+                    return;
                 }
                 const blob = new Blob(chunks, { type: recordingOptions.mimeType });
                 const file = new File([blob], `clip.${recordingOptions.fileExtension}`, {
                     type: recordingOptions.mimeType,
                 });
-                resolve(file);
+                finish(() => resolve(file));
             };
 
             recorder.onerror = (event: Event) => {
-                stream.getTracks().forEach((track) => track.stop());
+                stopTracks();
                 const err = (event as unknown as { error?: { name?: string } }).error;
-                reject(new Error("MediaRecorder error: " + (err?.name || "Unknown error")));
+                finish(() =>
+                    reject(new Error("MediaRecorder error: " + (err?.name || "Unknown error")))
+                );
             };
 
             recorder.start();
-            setTimeout(() => {
-                if (recorder.state === "recording") recorder.stop();
+            // Stop at the intended clip length.
+            window.setTimeout(() => {
+                try {
+                    if (recorder.state === "recording") recorder.stop();
+                } catch {
+                    // Nothing to do; the safety timeout below is the backstop.
+                }
             }, duration);
+            // Backstop: if the stream's tracks died so the recorder went inactive
+            // without ever firing onstop, settle anyway so the caller is never
+            // stuck on "Recording..." forever.
+            window.setTimeout(() => {
+                finish(() => {
+                    stopTracks();
+                    reject(new Error("Recording timed out."));
+                });
+            }, duration + 4000);
         } catch (e) {
-            stream.getTracks().forEach((track) => track.stop());
-            reject(e);
+            stopTracks();
+            finish(() => reject(e));
         }
     });
 }

--- a/apps/frontend/src/shared/components/WordDialog.tsx
+++ b/apps/frontend/src/shared/components/WordDialog.tsx
@@ -33,6 +33,7 @@ import { apiGetTemplate, streamBreakdown } from "@/shared/llm/api";
 import { toastApiError } from "@/shared/api/errors";
 import { toHiragana } from "@/shared/japanese/kana";
 import { createAndSaveClip } from "@/shared/clips/create";
+import { warmupRecorder } from "@/shared/clips/recorder";
 import { Badge, cn } from "@/shared/ui";
 import type { EnrichedJapaneseWord, KotobaseData, Token } from "@/shared/dict/types";
 import type { BreakdownResponse } from "@/shared/llm/types";
@@ -346,6 +347,11 @@ export default function WordDialog({
             toast.error("No Video Source Available");
             return;
         }
+        // Resume the recorder's AudioContext now, while the click gesture is
+        // still active. The breakdown fetch below can take seconds, after which
+        // the activation is spent and the iOS canvas-fallback recorder can no
+        // longer bring up its audio pipeline.
+        warmupRecorder();
         setSaving(true);
         try {
             let breakdown = breakdownCache.get(key) ?? null;

--- a/apps/mirumoji/pyproject.toml
+++ b/apps/mirumoji/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mirumoji"
-version = "3.5.0"
+version = "3.5.1"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "Self-Hostable Japanese Language Immersion Tool"

--- a/apps/mirumoji/src/mirumoji/__init__.py
+++ b/apps/mirumoji/src/mirumoji/__init__.py
@@ -7,4 +7,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("mirumoji")
 except PackageNotFoundError:
-    __version__ = "3.5.0"
+    __version__ = "3.5.1"

--- a/apps/mirumoji/src/mirumoji/launcher/modal/app.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/app.py
@@ -5,24 +5,58 @@ Builds a FastAPI application that serves the built React frontend and mounts
 the server's routers under `/api`, so a single Modal ASGI app answers both the
 `SPA` and the `API` on one origin
 
-The server's own `create_app` factory is left untouched, this reuses its
-lifespan, exception handlers, and routers by import
+info: Local-Disk Data With Background Volume Sync
+    - The persistent `modal.Volume` is not mounted on the path where the server
+      reads and writes user data. Instead the server operates on the
+      container's local disk (`CONTAINER_CACHE`) and a background task mirrors
+      every change to the volume mount (`DATA_MOUNT`)
+
+    - This keeps media serving and database access off the volume's `FUSE`
+      layer, whose per-request random reads are slow enough to stall video
+      playback, while `Modal`'s background and shutdown volume commits still
+      persist the data durably
+
+The server's own `create_app` factory is left untouched. This wraps its
+`lifespan` (never modifying it) and reuses its exception handlers and routers
+by import
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+import shutil
+import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .auth import BasicAuthMiddleware
-from .constants import WEB_PASSWORD_ENV, WEB_USERNAME
+from .constants import (
+    CONTAINER_CACHE,
+    DATA_MOUNT,
+    WEB_PASSWORD_ENV,
+    WEB_USERNAME,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from fastapi import FastAPI
 
 LOGGER = logging.getLogger(__name__)
+
+_HOST_EXIT_BUDGET_S = 10.0
+"""
+Seconds the host waits for a clean shutdown before forcing the process to exit
+
+A stranded `FUSE` write on a non-daemon thread (the volume syncer, or `Modal`'s
+own volume commit) can keep the process alive past `Modal`'s shutdown grace, so
+a daemon watchdog forces the exit within this budget, which sits comfortably
+above a normal shutdown and below `Modal`'s grace, turning a grace-period
+`SIGKILL` into a clean exit
+"""
 
 
 def _is_within(root: Path, path: Path) -> bool:
@@ -66,6 +100,281 @@ def _cache_control(full_path: str) -> str:
     return "no-cache"
 
 
+def _remove(path: Path) -> None:
+    """
+    Removes a file or a directory tree at `path`, tolerating a missing target
+
+    Args:
+        path (Path): The path to remove
+    """
+    if path.is_dir():
+        shutil.rmtree(path, ignore_errors=True)
+    elif path.exists():
+        path.unlink()
+
+
+def _dir_size(root: Path) -> int:
+    """
+    Returns the total size in bytes of every file under `root`
+
+    Used only for the warmup benchmark log, so a file vanishing mid-walk
+    or any other `OSError` is skipped rather than raised
+
+    Args:
+        root (Path): The directory to measure
+
+    Returns:
+        The summed size of every file under `root`
+    """
+    total = 0
+    for path in root.rglob("*"):
+        try:
+            if path.is_file():
+                total += path.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _shutdown_log(message: str) -> None:
+    """
+    Writes a host-shutdown message straight to stdout
+
+    question: Why Not `LOGGER`
+        - The core lifespan tears logging down as its final shutdow
+          step, so by the time the host's shutdown code runs the
+          logger has no handlers
+
+        - Writing to stdout keeps these lines in `Modal`'s captured
+          container logs
+
+    Args:
+        message (str): The message to write
+    """
+    print(f"[mirumoji-host] {message}", flush=True)
+
+
+def _arm_shutdown_watchdog() -> None:
+    """
+    Starts a daemon thread that forces the process to exit if a clean shutdown
+    overruns `_HOST_EXIT_BUDGET_S`
+
+    info: Why
+        - A `FUSE` write left running on a non-daemon worker thread can block
+          interpreter exit long enough to overrun `Modal`'s shutdown grace,
+          which then reports a `SIGKILL` failure
+
+        - A daemon thread never blocks a clean exit, so when shutdown finishes
+          in time the process exits first and the watchdog dies with it. Only a
+          genuinely stuck shutdown ever reaches the `os._exit`
+    """
+    import threading
+
+    def _force_exit() -> None:
+        time.sleep(_HOST_EXIT_BUDGET_S)
+        _shutdown_log(
+            f"[Shutdown Watcher] Shutdown Exceeded "
+            f"{_HOST_EXIT_BUDGET_S:.0f}s, Forcing Exit"
+        )
+        os._exit(0)
+
+    threading.Thread(
+        target=_force_exit,
+        name="host-exit-watchdog",
+        daemon=True,
+    ).start()
+
+
+async def _warm_cache(cache: Path, mount: Path) -> None:
+    """
+    Restores the local cache from the volume at startup
+
+    Copies the persisted user data from the volume mount into the local cache
+    so a redeployed or restarted container serves the user's existing database
+    and media. A first-ever deploy has an empty volume and copies nothing
+
+    info: Benchmark
+        Logs the restored size and elapsed time, since this bulk read off the
+        volume is the one unavoidable `FUSE` cost and dominates cold-start time
+
+    info: Fail-Closed
+        Re-raises on any copy error, so the caller aborts startup rather than
+        let the app run on a partial cache that the syncer would then mirror
+        back over the intact volume
+
+    Args:
+        cache (Path): The local cache directory to populate
+        mount (Path): The mounted volume directory to restore from
+
+    Raises:
+        OSError: If the restore copy fails
+    """
+    if not mount.exists() or not any(mount.iterdir()):
+        LOGGER.info(f"[Warm Cache] Volume '{mount}' Empty, Nothing To Warm")
+        return
+    LOGGER.info(
+        f"[Warm Cache] Warming Cache From Volume '{mount}' -> '{cache}'"
+    )
+    start = time.perf_counter()
+    await asyncio.to_thread(shutil.copytree, mount, cache, dirs_exist_ok=True)
+    elapsed_ms = (time.perf_counter() - start) * 1000
+    size_mib = _dir_size(cache) / (1024 * 1024)
+    LOGGER.info(
+        f"[Warm Cache] Warmed {size_mib:.1f}MiB Into "
+        f"Cache In {elapsed_ms:.1f}ms"
+    )
+
+
+async def _volume_syncer(cache: Path, mount: Path) -> None:
+    """
+    Long-running background task mirroring every change under `cache` to
+    `mount` for the whole application lifespan, so user data written to the
+    fast local disk is persisted to the `Modal` volume
+
+    question: Why
+        - The server reads and writes user data on `cache` (local container
+          disk) rather than on the volume mount, keeping media serving and
+          database access off the volume's slow `FUSE` layer
+
+        - This task copies additions and modifications to `mount` and removes
+          deletions from it, so `Modal`'s background and shutdown commits
+          persist the data
+
+    info: Resilience
+        - Every filesystem operation is guarded, so one failed copy or delete
+          is logged and never stops the task
+
+        - If the watcher itself errors, it is restarted after a short backoff,
+          so a transient failure does not silently end syncing
+
+        - Exits promptly on cancellation at shutdown
+
+    Args:
+        cache (Path): The local directory the server reads and writes
+        mount (Path): The mounted volume directory kept in sync with `cache`
+    """
+    # watchfiles ships as a `modal` dependency, so it is always importable in
+    # the container the host runs in
+    from watchfiles import Change, awatch
+
+    LOGGER.info(f"[Volume Syncer] Watching '{cache}' -> '{mount}'")
+    while True:
+        try:
+            async for changes in awatch(cache):
+                for change_type, src_str in changes:
+                    src = Path(src_str)
+                    try:
+                        rel = src.relative_to(cache)
+                    except ValueError:
+                        # Not under the cache, ignore
+                        continue
+                    dest = mount / rel
+                    try:
+                        if change_type is Change.deleted:
+                            await asyncio.to_thread(_remove, dest)
+                            LOGGER.info(f"[Volume Syncer] Removed '{rel}'")
+                        elif src.is_file():
+                            dest.parent.mkdir(parents=True, exist_ok=True)
+                            await asyncio.to_thread(shutil.copy2, src, dest)
+                            LOGGER.info(f"[Volume Syncer] Copied '{rel}'")
+                    except Exception as e:
+                        LOGGER.error(
+                            f"[Volume Syncer] Failed To Sync "
+                            f"'{src}' -> '{dest}' : {e}"
+                        )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            LOGGER.error(f"[Volume Syncer] Watcher Failed, Restarting : {e}")
+            await asyncio.sleep(1.0)
+
+
+def _log_syncer_exit(task: asyncio.Task[None]) -> None:
+    """
+    Done-callback that surfaces an unexpected volume-syncer exit
+
+    A cancelled syncer is the normal shutdown path and is ignored. Any other
+    exit means the background mirror stopped while the app was still running,
+    which is logged so it is not silent
+
+    Args:
+        task (asyncio.Task[None]): The finished syncer task
+    """
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        LOGGER.error(f"[Volume Syncer] Exited Unexpectedly : {exc}")
+
+
+@asynccontextmanager
+async def modal_host_lifespan(host_app: FastAPI) -> AsyncIterator[None]:
+    """
+    Wraps the server's core lifespan with the host's local-disk + volume-sync
+    persistence, without modifying the core lifespan
+
+    info: Startup Steps
+        - Ensures the local cache exists
+
+        - Warms it from the volume (restoring the user's data on a
+          redeploy or restart)
+
+        - Starts the background volume syncer BEFORE the core lifespan, so
+          every file the core startup writes (the database, the media tree) is
+          mirrored to the volume
+
+        - Runs the core lifespan
+
+    info: Shutdown
+        After the core lifespan's teardown (so the database is already closed)
+
+        - A watchdog is armed at shutdown onset so a stranded `FUSE` write can
+          never keep the container alive past `Modal`'s grace
+
+        - Cancels the syncer
+
+        - `Modal`'s background and final volume commits persist everything the
+          syncer copied, so no explicit reconciliation or commit is needed
+
+    info: Core Untouched
+        The server's `lifespan` runs verbatim through `async with`, so the
+        Docker deployment that shares it is unaffected
+
+    Args:
+        host_app (FastAPI): The host application whose lifecycle is managed
+
+    Yields:
+        Control to the running application, matching the core lifespan's yield
+    """
+    from ...server.app import lifespan
+
+    LOGGER.info("[Host Lifespan] Started Host Config")
+
+    cache = Path(CONTAINER_CACHE)
+    mount = Path(DATA_MOUNT)
+    syncer: asyncio.Task[None] | None = None
+    try:
+        cache.mkdir(parents=True, exist_ok=True)
+        LOGGER.info(f"[Host Lifespan] Container Cache Ready At '{cache}'")
+        # A Failed Warmup Must Abort Startup, Never Run The App On Partial Data
+        await _warm_cache(cache, mount)
+        LOGGER.info("[Host Lifespan] Starting Volume Syncer")
+        syncer = asyncio.create_task(_volume_syncer(cache, mount))
+        syncer.add_done_callback(_log_syncer_exit)
+        async with lifespan(host_app):
+            yield
+            # Healthy Shutdown Begins Here
+            # Guard Exit Before The Syncer And
+            # Modal's Volume Commit Run Their Final FUSE Writes
+            _arm_shutdown_watchdog()
+    finally:
+        if syncer is not None:
+            syncer.cancel()
+            await asyncio.gather(syncer, return_exceptions=True)
+            _shutdown_log("[Volume Syncer] Stopped")
+        _shutdown_log("[Host Lifespan] Host Teardown Complete")
+
+
 def create_host_app(frontend_dir: Path) -> FastAPI:
     """
     Builds the FastAPI application server by the `mirumoji-host` Modal app
@@ -73,10 +382,14 @@ def create_host_app(frontend_dir: Path) -> FastAPI:
     info: Additive
         - Does not modify or call `server.app.create_app`
 
-        - Reuses the server's `lifespan`, exception handlers, and routers by
-          import, mounting the routers under `/api` (matching the frontend's
-          relative `/api` base) and serving the built frontend as a single-page
-          app for everything else
+        - Reuses the server's exception handlers and routers by import,
+          mounting the routers under `/api` (matching the frontend's relative
+          `/api` base) and serving the built frontend as a single-page app for
+          everything else
+
+        - Wraps the server's `lifespan` in `modal_host_lifespan`, which adds
+          the local-disk + volume-sync persistence without changing the core
+          lifespan
 
     info: Access Gate
         - When `MIRUMOJI_WEB_PASSWORD` is set, the whole app is wrapped in HTTP
@@ -110,11 +423,9 @@ def create_host_app(frontend_dir: Path) -> FastAPI:
 
     from ...exceptions import MirumojiServerError
     from ...log import takeover_logging
-    from ...paths import HOST_LOG_PATH
     from ...server import media
     from ...server.app import (
         http_exception_handler,
-        lifespan,
         mirumoji_exception_handler,
     )
     from ...server.config import get_settings
@@ -125,8 +436,9 @@ def create_host_app(frontend_dir: Path) -> FastAPI:
     from ...server.routers.llm import llm_router
     from ...server.routers.profile import profile_router
 
+    # No FileHandler. Modal captures container stdout natively
     takeover_logging(
-        log_file="backend.log",
+        log_file=None,
         console=True,
         level=get_settings().logging_level,
     )
@@ -135,12 +447,12 @@ def create_host_app(frontend_dir: Path) -> FastAPI:
 
     LOGGER.info("App Build Started")
 
-    LOGGER.info(f"Storing Logs At '{HOST_LOG_PATH / 'backend.log'}'")
+    LOGGER.info("Logging To Stdout (Captured By Modal)")
 
     app = FastAPI(
         title="Mirumoji",
         description="Japanese sentence breakdown, audio processing and LLM.",
-        lifespan=lifespan,
+        lifespan=modal_host_lifespan,
     )
 
     for router in (
@@ -154,7 +466,9 @@ def create_host_app(frontend_dir: Path) -> FastAPI:
 
     # The server serves user media under `media.BASE_PATH`, one level below the
     # frontend so the SPA catch-all never shadows it. `check_dir=False` because
-    # the directory is created by `media.init_storage()` in the lifespan
+    # the directory is created by `media.init_storage()` in the lifespan.
+    # `media.BASE_PATH` is on the container's local disk (`CONTAINER_CACHE`),
+    # not the volume mount, so serving media never touches the slow FUSE layer
     app.mount(
         "/api/media",
         StaticFiles(directory=media.BASE_PATH, check_dir=False),

--- a/apps/mirumoji/src/mirumoji/launcher/modal/auth.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/auth.py
@@ -20,6 +20,7 @@ question: Why Basic Auth
 from __future__ import annotations
 
 import base64
+import hashlib
 import hmac
 from collections.abc import Awaitable, Callable, MutableMapping
 from typing import Any
@@ -31,6 +32,79 @@ Receive = Callable[[], Awaitable[Message]]
 Send = Callable[[Message], Awaitable[None]]
 ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
+_COOKIE_NAME = "mirumoji_auth"
+"""
+Name of the cookie that persists a passed `HTTP Basic Auth` check
+"""
+
+_COOKIE_MAX_AGE = 60 * 60 * 24 * 30
+"""
+Lifetime in seconds of the persistent auth cookie (30 days)
+
+info: Why A Cookie
+    - An installed `iOS` `PWA` does not retain the browser's `Basic Auth`
+      credential cache across suspend or close, so it re-prompts for the
+      password on every reopen
+
+    - After a passed `Basic Auth` check, the middleware sets this cookie and
+      then accepts it in place of the credentials, so a reopened `PWA`
+      authenticates silently until the cookie expires
+"""
+
+_PUBLIC_PATHS: frozenset[str] = frozenset(
+    {
+        "/manifest.webmanifest",
+        "/favicon.ico",
+        "/icons/icon-192.png",
+        "/icons/icon-512.png",
+        "/screenshots/desktop_screenshot.png",
+        "/screenshots/mobile_screenshot.png",
+    }
+)
+"""
+The exact request paths served without auth so that the PWA can install behind
+the gate
+
+info: Source Of Truth
+    - files under `apps/frontend/public/` + the icons and screenshots declared
+      in the vite PWA manifest
+
+    - Every entry is a real, unhashed file, so an ungated request can never
+      fall through to the SPA shell
+"""
+
+
+def _is_public_asset(path: str) -> bool:
+    """
+    Reports whether a request path is a public `PWA` install asset served
+    without `HTTP Basic Auth`
+
+    question: Why Ungate These
+        - The browser fetches the web app manifest, its icons, and the
+          `apple-touch-icon` as install-prompt subresources, and `iOS Safari`
+          does not attach the cached Basic Auth credentials to them
+
+        - If left gated, they answer `401`, so the install prompt has no name
+          or icon and the home-screen icon never renders
+
+        - They carry no user data, so serving exactly these files open keeps
+          the shell, the hashed assets, and the API fully gated while letting
+          the `PWA` install
+
+    info: Exact Match Only
+        Only the real files are ungated (no prefix), so an ungated path always
+        resolves to a genuine file and can never reach the `SPA` catch-all,
+        which would otherwise serve the gated `index.html` to an
+        unauthenticated client
+
+    Args:
+        path (str): The request path from the ASGI scope
+
+    Returns:
+        `True` when the path is a public install asset
+    """
+    return path in _PUBLIC_PATHS
+
 
 class BasicAuthMiddleware:
     """
@@ -41,12 +115,27 @@ class BasicAuthMiddleware:
           show its own credential prompt and then send `Authorization: Basic`
           on every later request, including the top-level navigation
 
-        - This needs no login page, session, or cookie, so the app and the
-          frontend are unchanged
+        - This needs no login page or session, so the server and the frontend
+          are unchanged
 
     info: Constant-Time
-        The credentials are compared with `hmac.compare_digest`, so the check
-        does not leak the password through timing
+        The credentials and the cookie are compared with `hmac.compare_digest`,
+        so the check does not leak the secret through timing
+
+    info: Public Install Assets
+        A short allowlist of `PWA` install files (the manifest, icons, and
+        screenshots) is served without auth, since the browser fetches them
+        without credentials and gating them breaks the install (see
+        `_is_public_asset`)
+
+    info: Persistent Cookie
+        - After a passed check, the middleware sets a signed cookie derived
+          from the password and accepts that cookie in place of the credentials
+
+        - An installed `iOS` `PWA` drops the browser's `Basic Auth` cache when
+          it is suspended or closed, so without the cookie it re-prompts on
+          every reopen. The cookie persists that state, and rotating the
+          password invalidates every previously issued cookie
     """
 
     def __init__(
@@ -70,6 +159,19 @@ class BasicAuthMiddleware:
         self._app = app
         token = base64.b64encode(f"{username}:{password}".encode())
         self._expected = b"Basic " + token
+        # A stateless token derived from the password, so the cookie is
+        # validated without any server-side session store. Rotating the
+        # password changes this token and invalidates every previously
+        # issued cookie
+        self._cookie_token = hmac.new(
+            password.encode(), b"mirumoji-auth", hashlib.sha256
+        ).hexdigest()
+        cookie = (
+            f"{_COOKIE_NAME}={self._cookie_token}; "
+            f"Max-Age={_COOKIE_MAX_AGE}; "
+            "Path=/; Secure; HttpOnly; SameSite=Lax"
+        )
+        self._set_cookie_header = (b"set-cookie", cookie.encode("latin-1"))
         self._challenge_headers: list[tuple[bytes, bytes]] = [
             (
                 b"www-authenticate",
@@ -85,8 +187,9 @@ class BasicAuthMiddleware:
         send: Send,
     ) -> None:
         """
-        Gates HTTP requests with the headers set up in `__init__` and passes
-        other scopes straight through
+        Gates HTTP requests, letting a valid persistent cookie or `Basic Auth`
+        through and passing other scopes and the public `PWA` install assets
+        straight through
 
         Args:
             scope (Scope): The ASGI connection scope
@@ -97,12 +200,24 @@ class BasicAuthMiddleware:
             await self._app(scope, receive, send)
             return
 
+        if _is_public_asset(scope.get("path", "")):
+            await self._app(scope, receive, send)
+            return
+
         headers = dict(scope.get("headers") or [])
+
+        # A valid persistent cookie authenticates silently, so an installed PWA
+        # that dropped its Basic Auth cache on suspend is not re-prompted
+        if self._cookie_valid(headers.get(b"cookie")):
+            await self._app(scope, receive, send)
+            return
+
+        # A valid Basic Auth check passes and mints the cookie for next time
         supplied = headers.get(b"authorization")
         if supplied is not None and hmac.compare_digest(
             supplied, self._expected
         ):
-            await self._app(scope, receive, send)
+            await self._app(scope, receive, self._send_with_cookie(send))
             return
 
         await send(
@@ -118,3 +233,45 @@ class BasicAuthMiddleware:
                 "body": b"Authentication Required",
             }
         )
+
+    def _cookie_valid(self, cookie_header: bytes | None) -> bool:
+        """
+        Reports whether the request carries a valid persistent auth cookie
+
+        Args:
+            cookie_header (bytes | None): The raw `Cookie` request header, or
+                `None` when absent
+
+        Returns:
+            `True` when the cookie's value matches the expected token
+        """
+        if not cookie_header:
+            return False
+        for part in cookie_header.decode("latin-1").split(";"):
+            name, _, value = part.strip().partition("=")
+            if name == _COOKIE_NAME:
+                return hmac.compare_digest(value, self._cookie_token)
+        return False
+
+    def _send_with_cookie(self, send: Send) -> Send:
+        """
+        Wraps `send` so the persistent auth cookie is set on the response
+
+        Injects the `Set-Cookie` header into the response start, so a client
+        that just passed `Basic Auth` carries the cookie on its next visit
+
+        Args:
+            send (Send): The ASGI send channel to wrap
+
+        Returns:
+            A send channel that adds the cookie to the response start
+        """
+
+        async def wrapped(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                cookied = list(message.get("headers") or [])
+                cookied.append(self._set_cookie_header)
+                message = {**message, "headers": cookied}
+            await send(message)
+
+        return wrapped

--- a/apps/mirumoji/src/mirumoji/launcher/modal/constants.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/constants.py
@@ -6,9 +6,10 @@ info: Pre-Defined Values
       that runs the `FastAPI` application
       (`HOST_APP_NAME`, `WEB_FUNCTION_NAME`)
 
-    - The name of the persistent `Modal` volume used to store user data and the
-      location in which its mounted in the `web function's` container
-      (`DATA_VOLUME_NAME`, `DATA_MOUNT`)
+    - The name of the persistent `Modal` volume used to store user data, the
+      separate path at which it is mounted, and the local-disk path the server
+      reads and writes and the syncer mirrors to the volume
+      (`DATA_VOLUME_NAME`, `DATA_MOUNT`, `CONTAINER_CACHE`)
 
     - Where the built frontend lives inside the Docker image run by the
       `web function` and where the frontend lives inside mirumoji's published
@@ -44,26 +45,31 @@ DATA_VOLUME_NAME = "mirumoji-data"
 The persistent `modal.Volume` name backing the database and media
 """
 
-DATA_MOUNT = "/root/.local/share/mirumoji"
+DATA_MOUNT = "/opt/mirumoji/volume_mnt"
 """
-Where the persistent `Volume` mounts, matching the container's platformdirs
-`user_data_path` so the server's storage lands on the volume unchanged (the
-same path the Docker `data` volume uses)
+Where the persistent `Volume` mounts inside the container
+
+The volume is mounted in the container at this path only so that
+a background task can utilise the mount's FUSE syncing to persist
+user data from the `CONTAINER_CACHE` to the volume on file-system
+changes. Therefore, this directory is always kept in sync with
+`CONTAINER_CACHE` throughout the application's lifespan
 """
 
-STATE_MOUNT = f"{DATA_MOUNT}/state"
+CONTAINER_CACHE = "/root/.local/share/mirumoji"
 """
-Value for the container's `XDG_STATE_HOME`, kept under `DATA_MOUNT`
+Where the mirumoji user data lives inside the container, matching the
+container's platformdirs `user_data_path`
 
-question: Why
-    - On Linux, `platformdirs` places the log directory under the state dir
-      (`XDG_STATE_HOME`), which is a separate top-level path from the data dir,
-      so server logs would otherwise land on ephemeral container storage
-      instead of the mounted volume
+info: Data Handling
+    - Instead of mounting the persistent volume directly on this path,
+      a background task watches this directory and keeps the volume
+      in sync with it
 
-    - Pointing `XDG_STATE_HOME` beneath the volume mount makes the logs persist
-      on the volume alongside the database and media, using the standard XDG
-      mechanism rather than a mirumoji-specific path override
+    - This allows the application to serve files and perform database
+      operations directly on the container's NVMe, avoiding network
+      latency on file operations, which would considerably slow down
+      the application
 """
 
 FRONTEND_DIR = "/opt/mirumoji/frontend"

--- a/apps/mirumoji/src/mirumoji/launcher/modal/host.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/host.py
@@ -26,10 +26,11 @@ info: Compute
     - It also always scales to zero, preventing unexpected idle-GPU costs
 
 info: Persistence
-    - A named `modal.Volume` is mounted at the container's `platformdirs` data
-      path (where the mirumoji server keeps all user data) on every startup,
-      so the database and media persist exactly as the Docker `data` volume
-      does
+    - A named `modal.Volume` is mounted at `DATA_MOUNT`, a path separate from
+      the server's data path. The server reads and writes user data on the
+      container's local disk, and a background task (see `launcher.modal.app`)
+      mirrors it to the volume, keeping media and database I/O off the slow
+      volume FUSE layer while `Modal`'s volume commits still persist it durably
 
     - `mirumoji modal deploy` creates that volume in the user's `Modal`
       workspace when it doesn't exist, and `mirumoji modal stop -v` allows
@@ -68,7 +69,6 @@ from .constants import (
     HOST_CPU_VAR,
     HOST_MAX_CONCURRENT_REQUESTS_VAR,
     HOST_MEMORY_VAR,
-    STATE_MOUNT,
 )
 
 if TYPE_CHECKING:
@@ -86,11 +86,6 @@ def _host_image(version: str) -> modal.Image:
     Kotobase data) and copies the already-published frontend build in, so the
     deploy needs no new artifact
 
-    info: Log Persistence
-        Sets `XDG_STATE_HOME` under the volume mount so the server's logs
-        (which platformdirs places under the state dir on Linux) land on the
-        persistent volume rather than ephemeral container storage
-
     Args:
         version (str): The published image version to compose from
 
@@ -99,11 +94,9 @@ def _host_image(version: str) -> modal.Image:
     """
     frontend = FRONTEND_IMAGE.format(version=version)
     copy = f"COPY --from={frontend} {FRONTEND_IMAGE_ROOT} {FRONTEND_DIR}"
-    return (
-        modal.Image.from_registry(BACKEND_CPU_IMAGE.format(version=version))
-        .dockerfile_commands(copy)
-        .env({"XDG_STATE_HOME": STATE_MOUNT})
-    )
+    return modal.Image.from_registry(
+        BACKEND_CPU_IMAGE.format(version=version)
+    ).dockerfile_commands(copy)
 
 
 def web() -> FastAPI:
@@ -169,8 +162,8 @@ def build_host_app(
           transcription is never cut off and the in-process job queue runs
 
         - `max_containers=1` pins the count to one, since the server holds
-          in-process state and writes a single-writer SQLite file on the
-          volume, so it can't run as multiple replicas
+          in-process state and writes a single-writer SQLite file on local
+          disk (mirrored to the volume), so it can't run as multiple replicas
 
         - The pinned count also makes a scaledown window unnecessary, so none
           is set

--- a/apps/mirumoji/src/mirumoji/server/routers/jobs.py
+++ b/apps/mirumoji/src/mirumoji/server/routers/jobs.py
@@ -25,7 +25,11 @@ from fastapi import (
 
 from ..db import UnitOfWork
 from ..db.models import JobDTO
-from ..dependencies import ensure_profile_exists, get_job_manager
+from ..dependencies import (
+    ensure_profile_exists,
+    get_job_manager,
+    get_profile_id_optional,
+)
 from ..jobs import JobQueueManager
 from ..models.requests import SubmitBatchRequest, SubmitJobRequest
 from ..models.responses import JobResponse
@@ -198,22 +202,31 @@ async def submit_batch(
 
 @jobs_router.get("", response_model=list[JobResponse])
 async def list_jobs(
-    profile_id: Annotated[str, Depends(ensure_profile_exists)],
+    profile_id: Annotated[str | None, Depends(get_profile_id_optional)],
     active: Annotated[bool, Query()] = False,
 ) -> list[JobResponse]:
     """
     Lists the active profile's top-level jobs (batch children are excluded)
 
+    info: Profile Optional
+        A poll that arrives without `X-Profile-ID` (a service-worker replay,
+        which cannot inject the app header) returns an empty list rather than a
+        `400`, so it does not surface as a spurious error
+
     Args:
-        profile_id (str): Validated profile id
+        profile_id (str | None): Validated profile id, or `None` when the
+            header is absent
         active (bool): Restrict to `queued` / `running` jobs
 
     Returns:
-        The profile's jobs, newest first
+        The profile's jobs, newest first, or an empty list when no profile is
+        set
 
     Raises:
         DatabaseError: If the query fails
     """
+    if profile_id is None:
+        return []
     async with UnitOfWork() as uow:
         jobs = await uow.jobs.list_for_profile(profile_id, active_only=active)
     return [_to_response(j) for j in jobs]

--- a/docs/site/docs_md/project/changelog.md
+++ b/docs/site/docs_md/project/changelog.md
@@ -19,6 +19,62 @@ starting from **`v3.0.0`**
 
 ---
 
+## [`3.5.1`](https://github.com/svdC1/mirumoji/releases/tag/v3.5.1) - 2026-07-16
+
+This release fixes several issues with the `Modal`-hosted deploy. It moves media serving and the
+database off the volume's slow network layer so hosted video plays smoothly,
+makes shutdown and spot preemption exit cleanly, completes the `PWA` install
+behind the host login on `iOS`, and stops the installed app from re-prompting for
+the password. It also fixes a previously uncaught clip-recording hang on `iOS`.
+It has no breaking changes
+
+### Fixed
+
+- `Launcher` &rarr; Besides an overall poor application performance when hosting on `Modal`,
+  video playback stalled and clip recording failed. The `Modal` host served media and ran
+  the database directly off the persistent volume's `FUSE` layer, whose per-request random
+  reads take seconds, so every seek re-buffered and the browser recorder
+  *(which captures live playback)* had no continuous stream to record.
+  The host now reads and writes user data on the container's local disk and mirrors changes
+  to the volume in the background, keeping media and database I/O off the slow layer while
+  `Modal` still persists the data
+
+- `Launcher` &rarr; The `Modal` host could overrun `Modal`'s shutdown grace and be
+  force-killed *(logging `Runner has been shutting down for too long`)* when a stop
+  or a spot preemption stranded an in-flight volume read on a background thread. A
+  watchdog *(a daemon thread started at shutdown that terminates the process if it doesn't
+  exit in less than 10 seconds)* now exits the container cleanly within the grace window,
+  so a stop or preemption releases promptly
+
+- `Launcher` &rarr; The `Modal` host wrote its request log to the persistent volume
+  on every request, growing it unbounded and adding a volume write to the hot
+  path. It now logs to standard output, which `Modal` captures, so nothing is
+  written to the volume. `Modal` persists logs natively through the `Stopped Apps`
+  interface, so writing to a log file would be redundant and decrease performance
+
+- `Frontend` &rarr; The installed `PWA` icon did not render on `iOS` and the app was
+  not installable behind the host login. `iOS` fetches the manifest, its icons, and
+  the `apple-touch-icon` as install subresources without the login, so behind
+  `HTTP Basic Auth` they returned `401`. The host now serves exactly those public
+  install files without auth, while the shell, the hashed assets, and the API stay
+  gated
+
+- `Frontend` &rarr; An installed `iOS` `PWA` re-prompted for the host password on
+  every reopen, since `iOS` drops the `Basic Auth` credential cache when the app is
+  suspended. A passed login now sets a persistent, `HttpOnly` cookie that the host
+  accepts in place of the credentials, so a reopened app authenticates silently
+  *(rotating the password invalidates it)*
+
+- `Frontend` &rarr; Saving a clip on `iOS` could hang on `Recording` from a fresh
+  player. The recorder's audio pipeline needs its `AudioContext` resumed inside a
+  user gesture, but fetching the word explanation first spent it, leaving the audio
+  track dead. The save now resumes the context on the tap, and the recorder can no
+  longer hang indefinitely
+
+- `Server` &rarr; `GET /api/jobs` returned `400` for a poll that arrived without an
+  `X-Profile-ID` header *(a service-worker replay the app cannot attach the header
+  to)*. It now returns an empty list, so the errors stop
+
 ## [`3.5.0`](https://github.com/svdC1/mirumoji/releases/tag/v3.5.0) - 2026-07-15
 
 This release makes the launcher run the container images that match the

--- a/docs/site/docs_md/setup/modal-host.md
+++ b/docs/site/docs_md/setup/modal-host.md
@@ -80,13 +80,20 @@ Once you log in, the whole app loads and works exactly like a local install, wit
 
     - A `401` makes the browser show its own prompt and then attach the credentials to `every` later request *(the page, the assets, the API, the uploads)* automatically
 
-    - That gates the whole app without a login page, cookies, or any change to the server or frontend, which keeps the app itself free of auth for its *primary* use as a self-hosted tool
+    - That gates the whole app without a login page or any change to the server or frontend, which keeps `Mirumoji` free of auth for its *primary* use as a self-hosted tool
+
+    - After the first login the host sets a persistent, `HttpOnly` cookie and accepts it in place of the prompt, so an installed `iOS` `PWA` *(which drops the `Basic Auth` credential cache whenever it is closed)* does not re-prompt for the password on every reopen. Changing `MIRUMOJI_WEB_PASSWORD` invalidates it
 
     - See [`Sharing Outside Your Network`](../guides/sharing.md#modal-host-private-full-deploy) for how this compares to the other sharing options and how to add identity-based access if you need it
 
 ## Your Data
 
 Unlike a local install *(which keeps your data in local Docker volumes)*, the hosted app stores your media and database in the `mirumoji-data` [`Modal Volume`](https://modal.com/docs/guide/volumes), created automatically on the first deploy
+
+???+ question "How It Stays Fast And Durable"
+    - The host does not read and write directly on the volume, whose network layer is slow for the many small, random reads that video playback and the database make. It operates on the container's local disk and mirrors every change to the volume in the background
+
+    - `Modal` commits the volume as the app runs and on shutdown, and the host restores it into the container on every start, so your data survives a redeploy, a stop, or a spot preemption
 
 === "Back It Up"
     Download everything in the volume to a local folder at any time


### PR DESCRIPTION
# 3.5.1 Summary

Fix-only release (no breaking changes) targeting the `Modal`-hosted deploy. It reworks how the
host stores and serves user data so that hosted video plays smoothly, makes shutdown and spot
preemption exit cleanly, completes the PWA install and login persistence on iOS, and fixes an
iOS clip-recording hang


## Host Persistence (7bf61a7)

### Performance Problem

The host mounted the `mirumoji-data` volume directly on the `platformdirs` data path,
so the SQLite DB and all media lived on the volume's FUSE layer. That layer lazily fetches
uncached regions from remote storage, so per-request random reads take multiple seconds.
`StaticFiles` serving the converted `.mp4` over HTTP Range answered each seek in 5-26 s
server-side, so playback constantly re-buffered. Because clip recording captures the live
`<video>` stream client-side, broken playback also meant the recorder had no continuous stream
and the save silently never reached the server. Also, the host wrote its request log to the FUSE volume on every request (unbounded growth + a volume write on the hot path).

### Performance Fix

Invert the mount. The volume now mounts at a separate `DATA_MOUNT`
(`/opt/mirumoji/volume_mnt`) and the server reads/writes on the container's local NVMe at
`CONTAINER_CACHE` (`/root/.local/share/mirumoji`, the platformdirs data path), so `StaticFiles`
and the DB hit local disk. A background `_volume_syncer` (`watchfiles.awatch`) mirrors every
change from the cache to the mount, and `Modal`'s background + shutdown volume commits persist
it. `_warm_cache` restores the volume into the cache on start and a partial restore
aborts startup rather than mirror partial data back over the intact volume. The DB runs in WAL
mode and the syncer copies `mirumoji.db` + `-wal` + `-shm` together, so a restore is
crash-recoverable

`create_host_app` now calls `takeover_logging(log_file=None)` and logs to stdout, which `Modal`
captures durably. `host.py` also drops the defunct `XDG_STATE_HOME`/`STATE_MOUNT` redirect,
which referenced a constant removed in the redesign and would `ImportError` on container start

### Host Stranded On Shutdown Problem

A stop or a spot preemption can strand an in-flight FUSE read/write on a
non-daemon worker thread, keeping the process alive past `Modal`'s ~30 s grace and triggering a
`Runner has been shutting down for too long` SIGKILL

### Host Stranded On Shurdown Fix

`_arm_shutdown_watchdog` starts a daemon thread, armed at shutdown onset,
that `os._exit(0)`s after `_HOST_EXIT_BUDGET_S` (10 s) if the
process has not exited. A clean shutdown exits first and the daemon dies with it


## PWA Auth (74e2966)

### Install Assets Problem

iOS fetches the web-app manifest, its icons, and the `apple-touch-icon` as
install-prompt subresources *without* the Basic Auth credentials, so behind the host gate they
returned `401` and the home-screen icon never rendered (3.5.0's `useCredentials` fix only covered
Chromium's manifest fetch)

### Install Assets Fix 

`BasicAuthMiddleware` now serves an exact-path allowlist of the six
real public install files (`_is_public_asset`) without auth. Exact match, no prefix, so an
ungated path always resolves to a genuine file and can never fall through the SPA catch-all to
the gated `index.html`. The shell, hashed assets, and API stay gated

### iOS PWA Reload Problem

An installed iOS PWA drops the Basic Auth credential cache when suspended
or closed, re-prompting for the password on every reopen, which is very incovenient

### iOS PWA Reload Fix

On a passed Basic Auth check the middleware now mints a cookie (`Set-Cookie: mirumoji_auth=<hmac(password)>; Max-Age=30d; Path=/;Secure; HttpOnly; SameSite=Lax`) by wrapping the ASGI `send` to inject it into
`http.response.start`, and accepts that cookie (constant-time compared) in place of the
credentials on later requests, so a reopened app authenticates silently. The token is derived
from `MIRUMOJI_WEB_PASSWORD`, so rotating the password invalidates every issued cookie, and it is
stateless (no server-side session store)

## `/api/jobs` Returning 400s On A Profile-Less Poll (3f17ea0)

### Problem
Header-less requests to `/api/jobs` (service-worker replays that cannot attach the app's
`X-Profile-ID`) hit `ensure_profile_exists` and returned `400`

### Fix 

The read-only list now depends on `get_profile_id_optional` and returns `[]` when no profile is set.
This is the one change outside `launcher/modal/*` (it is in the shared server router), but an empty job
list for no profile is correct on every deployment.

## iOS Clip Recorder (ce5f3ea)

### Problem

On iOS Safari the recorder falls back to a canvas path whose audio comes from a
shared `AudioContext` created *suspended* at module load, which only resumes inside a user
gesture. Saving a clip from a fresh state awaits the word-breakdown SSE stream (~5 s) before
recording, spending the click's user activation, so the context never resumes, the audio track
is dead, and `MediaRecorder` never finalizes. The `if (recorder.state === "recording") recorder.stop()`
guard then turns that into an infinite hang on "Recording". It self-heals only once a recording succeeds
while the context is running, which is why pre-fetching the explanation made the next save work

### Fix

`warmupRecorder()` (new export) resumes the now lazily-created `AudioContext`, and
`WordDialog.handleSave` calls it synchronously on the tap, before the breakdown fetch, so the
context is running when recording starts. `createRecordingPromise` is also hardened with a
single-settle guard and a `duration + 4s` backstop timeout, so a stranded recorder can never hang
indefinitely: worst case it rejects with `Recording timed out.` (retryable) instead of freezing
