### PR TITLE
V37

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.6.0",
+    "version": "3.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mirumoji-ui",
-            "version": "3.6.0",
+            "version": "3.7.0",
             "dependencies": {
                 "@fontsource/hanken-grotesk": "^5.2.8",
                 "@fontsource/newsreader": "^5.2.10",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.6.0",
+    "version": "3.7.0",
     "private": true,
     "type": "module",
     "engines": {

--- a/apps/frontend/src/app/shell/TaskTray.tsx
+++ b/apps/frontend/src/app/shell/TaskTray.tsx
@@ -16,8 +16,17 @@ import type { Job } from "@/shared/jobs/types";
 import { cn, IconButton, Spinner } from "@/shared/ui";
 
 /** A row for a client-side upload that is feeding a job. */
-function UploadRow({ task, onDismiss }: { task: UploadTask; onDismiss: () => void }) {
+function UploadRow({
+    task,
+    onCancel,
+    onDismiss,
+}: {
+    task: UploadTask;
+    onCancel: () => void;
+    onDismiss: () => void;
+}) {
     const failed = task.status === "error";
+    const cancellable = !failed && task.cancellable === true;
     return (
         <li className="px-3 py-2.5">
             <div className="flex items-start gap-2.5">
@@ -40,8 +49,12 @@ function UploadRow({ task, onDismiss }: { task: UploadTask; onDismiss: () => voi
                     </p>
                     {!failed && <ProgressBar percent={task.progress} />}
                 </div>
-                {failed && (
-                    <IconButton label="Dismiss" onClick={onDismiss} className="shrink-0">
+                {(failed || cancellable) && (
+                    <IconButton
+                        label={cancellable ? "Cancel" : "Dismiss"}
+                        onClick={cancellable ? onCancel : onDismiss}
+                        className="shrink-0"
+                    >
                         <X size={15} />
                     </IconButton>
                 )}
@@ -112,7 +125,7 @@ function JobRow({
  * @returns {JSX.Element | null} The floating tray, or `null` when idle/empty.
  */
 export function TaskTray() {
-    const { jobs, uploads, busy, cancel, dismiss } = useTasks();
+    const { jobs, uploads, busy, cancel, cancelUpload, dismiss } = useTasks();
     const applyResult = useJobResult();
     const [open, setOpen] = useState(false);
 
@@ -158,7 +171,12 @@ export function TaskTray() {
                     </header>
                     <ul className="min-h-0 flex-1 divide-y divide-ink/5 overflow-y-auto">
                         {uploads.map((u) => (
-                            <UploadRow key={u.id} task={u} onDismiss={() => dismiss(u.id)} />
+                            <UploadRow
+                                key={u.id}
+                                task={u}
+                                onCancel={() => cancelUpload(u.id)}
+                                onDismiss={() => dismiss(u.id)}
+                            />
                         ))}
                         {jobs.map((j) => (
                             <JobRow

--- a/apps/frontend/src/contexts/TaskContext.tsx
+++ b/apps/frontend/src/contexts/TaskContext.tsx
@@ -17,6 +17,7 @@ import React, {
     ReactNode,
 } from "react";
 import { ApiError, toastApiError } from "@/shared/api/errors";
+import { isUploadAborted } from "@/shared/api/client";
 import { inferFileType } from "@/shared/format/files";
 import { useProfile } from "./ProfileContext";
 import {
@@ -42,6 +43,22 @@ const POLL_INTERVAL_MS = 2000;
 
 const ACTIVE_STATUSES: JobStatus[] = ["queued", "running"];
 
+/**
+ * Identity key for the upload cache.
+ *
+ * Keyed by content identity rather than by `File` object identity: re-picking
+ * the same file from the OS dialog yields a brand new `File`, which would miss
+ * a per-object cache and upload again. It also keeps the cache from retaining a
+ * strong reference to every `File` uploaded this session, which pinned
+ * multi-hundred-MB blobs in memory for the lifetime of the page.
+ *
+ * @param {File} file The file to key.
+ * @returns {string} A stable key for this file's contents.
+ */
+function fileKey(file: File): string {
+    return `${file.name}|${file.size}|${file.lastModified}`;
+}
+
 /** A client-side upload, shown in the tray during its upload. */
 export interface UploadTask {
     /** Client-generated id (distinct from server job ids). */
@@ -56,6 +73,8 @@ export interface UploadTask {
     status: "uploading" | "error";
     /** Failure message when `status` is `error`. */
     error?: string;
+    /** Whether this upload can still be cancelled. */
+    cancellable?: boolean;
 }
 
 /** Everything a submitted job needs beyond the uploaded file reference. */
@@ -92,10 +111,14 @@ export interface TaskContextType {
     waitFor: (id: string) => Promise<Job>;
     /** Cancels a queued or running job. */
     cancel: (id: string) => Promise<void>;
+    /** Aborts an in-flight upload by its tray id. */
+    cancelUpload: (id: string) => void;
     /** Permanently deletes a finished job (server-side) and drops it locally. */
     deleteJob: (id: string) => Promise<void>;
     /** Removes a finished job or a failed upload from the tray. */
     dismiss: (id: string) => void;
+    /** Forgets the cached profile file ids for the given ids. */
+    forgetUploaded: (fileIds: string[]) => void;
     /** Re-fetches the active jobs immediately. */
     refresh: () => Promise<void>;
 }
@@ -125,9 +148,16 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     const jobsRef = useRef<Job[]>([]);
     jobsRef.current = jobs;
 
-    // Re-upload elimination: remembers the profile file id for each File
-    // uploaded this session, so a second job on the same File skips the upload.
-    const uploadedRef = useRef(new Map<File, string>());
+    // Re-upload elimination: remembers the in-flight upload for each file
+    // uploaded this session, so a second job on the same file joins it instead
+    // of starting its own. The promise is stored (not the resolved id) and it is
+    // stored *before* the first await, so two actions fired together on one
+    // local file share a single upload rather than each uploading the whole
+    // file. Keyed by content identity, see `fileKey`.
+    const uploadedRef = useRef(new Map<string, Promise<UploadedFile>>());
+
+    // Abort controllers for in-flight uploads, keyed by their tray id.
+    const abortersRef = useRef(new Map<string, AbortController>());
 
     const refresh = useCallback(async () => {
         if (!profileId) return;
@@ -161,8 +191,14 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             }
         }
 
+        // A job we were tracking that neither appears as active nor could be
+        // fetched has been removed server-side (deleting a file cascades its
+        // jobs away), so it is dropped rather than kept forever. Without this
+        // the tray and the tasks list resurrect jobs that no longer exist.
+        const gone = new Set(justFinished.filter((j, i) => finished[i] === null).map((j) => j.id));
+
         setJobs((prev) => {
-            const byId = new Map(prev.map((j) => [j.id, j]));
+            const byId = new Map(prev.filter((j) => !gone.has(j.id)).map((j) => [j.id, j]));
             for (const j of active) byId.set(j.id, j);
             for (const j of finished) if (j) byId.set(j.id, j);
             return [...byId.values()].sort(byNewest);
@@ -173,6 +209,10 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     useEffect(() => {
         setJobs([]);
         setUploads([]);
+        // Abort anything still streaming, otherwise a switched-away profile
+        // keeps uploading into the profile the user just left.
+        for (const controller of abortersRef.current.values()) controller.abort();
+        abortersRef.current.clear();
         uploadedRef.current.clear();
         if (!profileId) return;
         let cancelled = false;
@@ -210,12 +250,20 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         if (files.length === 0) return 0;
         const uploadId = `lib-${Date.now()}`;
         const name = folder ?? `${files.length} File(s)`;
-        setUploads((prev) => [...prev, { id: uploadId, name, progress: 0, status: "uploading" }]);
+        const controller = new AbortController();
+        abortersRef.current.set(uploadId, controller);
+        setUploads((prev) => [
+            ...prev,
+            { id: uploadId, name, progress: 0, status: "uploading", cancellable: true },
+        ]);
         const patch = (changes: Partial<UploadTask>) =>
             setUploads((prev) => prev.map((u) => (u.id === uploadId ? { ...u, ...changes } : u)));
 
         let ok = 0;
         for (let i = 0; i < files.length; i++) {
+            // Cancelling the set stops before the next file rather than only
+            // aborting the one in flight.
+            if (controller.signal.aborted) break;
             try {
                 await uploadProfileFile(
                     files[i],
@@ -223,32 +271,52 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                     // Overall progress across the whole set.
                     (percent) => patch({ progress: ((i + percent / 100) / files.length) * 100 }),
                     () => undefined,
-                    folder
+                    folder,
+                    controller.signal
                 );
                 ok += 1;
-            } catch {
+            } catch (e) {
+                if (isUploadAborted(e)) break;
                 // Keep going; the panel reports the final success count.
             }
             patch({ progress: ((i + 1) / files.length) * 100 });
         }
+        abortersRef.current.delete(uploadId);
         setUploads((prev) => prev.filter((u) => u.id !== uploadId));
         return ok;
     }, []);
 
     const uploadAndSubmit = useCallback(
         async (file: File, options: SubmitOptions): Promise<Job | null> => {
-            // Reuse the file id when this exact File was already uploaded.
-            const cachedId = uploadedRef.current.get(file);
-            if (cachedId) {
-                return submit({
-                    type: options.jobType,
-                    file_id: cachedId,
-                    opts: options.opts,
-                    model: options.model,
-                    sys_msg: options.sysMsg,
-                });
+            const key = fileKey(file);
+            const pending = uploadedRef.current.get(key);
+            // Join the existing upload for this file, whether it already
+            // finished or is still streaming. Both branches are inside the try
+            // so a rejection (a stale file id the server no longer has) is
+            // reported rather than becoming an unhandled rejection.
+            if (pending) {
+                try {
+                    const uploaded = await pending;
+                    return await submit({
+                        type: options.jobType,
+                        file_id: uploaded.id,
+                        opts: options.opts,
+                        model: options.model,
+                        sys_msg: options.sysMsg,
+                    });
+                } catch (e) {
+                    // A rejected upload must not poison the cache, otherwise
+                    // every later action on this file replays the same failure.
+                    if (uploadedRef.current.get(key) === pending) {
+                        uploadedRef.current.delete(key);
+                    }
+                    throw e;
+                }
             }
+
             const uploadId = `upload-${file.name}-${Date.now()}`;
+            const controller = new AbortController();
+            abortersRef.current.set(uploadId, controller);
             setUploads((prev) => [
                 ...prev,
                 {
@@ -257,6 +325,7 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                     jobType: options.jobType,
                     progress: 0,
                     status: "uploading",
+                    cancellable: true,
                 },
             ]);
             const patch = (changes: Partial<UploadTask>) =>
@@ -264,14 +333,20 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                     prev.map((u) => (u.id === uploadId ? { ...u, ...changes } : u))
                 );
 
+            // Registered synchronously, before the first await, so a second
+            // action fired in the same tick finds it and joins.
+            const upload = uploadProfileFile(
+                file,
+                options.fileType,
+                (percent) => patch({ progress: percent }),
+                () => patch({ progress: 100, cancellable: false }),
+                undefined,
+                controller.signal
+            );
+            uploadedRef.current.set(key, upload);
+
             try {
-                const uploaded: UploadedFile = await uploadProfileFile(
-                    file,
-                    options.fileType,
-                    (percent) => patch({ progress: percent }),
-                    () => patch({ progress: 100 })
-                );
-                uploadedRef.current.set(file, uploaded.id);
+                const uploaded: UploadedFile = await upload;
                 const job = await submit({
                     type: options.jobType,
                     file_id: uploaded.id,
@@ -282,9 +357,20 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
                 setUploads((prev) => prev.filter((u) => u.id !== uploadId));
                 return job;
             } catch (e) {
+                if (uploadedRef.current.get(key) === upload) {
+                    uploadedRef.current.delete(key);
+                }
+                // A cancel is a deliberate action, so the row is dropped rather
+                // than left behind as a failure the user has to dismiss.
+                if (isUploadAborted(e)) {
+                    setUploads((prev) => prev.filter((u) => u.id !== uploadId));
+                    return null;
+                }
                 const message = e instanceof Error ? e.message : "Upload Failed";
-                patch({ status: "error", error: message });
-                return null;
+                patch({ status: "error", error: message, cancellable: false });
+                throw e;
+            } finally {
+                abortersRef.current.delete(uploadId);
             }
         },
         [submit]
@@ -307,14 +393,44 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         }
     }, []);
 
+    const cancelUpload = useCallback((id: string) => {
+        abortersRef.current.get(id)?.abort();
+    }, []);
+
     const deleteJob = useCallback(async (id: string) => {
-        await deleteJobApi(id);
-        setJobs((prev) => prev.filter((j) => j.id !== id));
+        try {
+            await deleteJobApi(id);
+        } catch (e) {
+            // A job that is already gone is the desired end state, so the row is
+            // dropped either way. Without this the tray can never shed a job the
+            // server removed (deleting a file cascades its jobs away), leaving a
+            // phantom row that 404s on every click.
+            if (!(e instanceof ApiError) || e.status !== 404) throw e;
+        } finally {
+            setJobs((prev) => prev.filter((j) => j.id !== id));
+        }
     }, []);
 
     const dismiss = useCallback((id: string) => {
         setJobs((prev) => prev.filter((j) => j.id !== id));
         setUploads((prev) => prev.filter((u) => u.id !== id));
+    }, []);
+
+    const forgetUploaded = useCallback((fileIds: string[]) => {
+        if (fileIds.length === 0) return;
+        const dropped = new Set(fileIds);
+        // Resolved entries pointing at a deleted profile file are dropped, so a
+        // later action on the same local file re-uploads instead of submitting
+        // against an id the server no longer has.
+        for (const [key, pending] of uploadedRef.current.entries()) {
+            void pending
+                .then((uploaded) => {
+                    if (dropped.has(uploaded.id) && uploadedRef.current.get(key) === pending) {
+                        uploadedRef.current.delete(key);
+                    }
+                })
+                .catch(() => undefined);
+        }
     }, []);
 
     const busy = uploads.some((u) => u.status === "uploading") || hasActiveJobs;
@@ -330,8 +446,10 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             uploadFiles,
             waitFor,
             cancel,
+            cancelUpload,
             deleteJob,
             dismiss,
+            forgetUploaded,
             refresh,
         }),
         [
@@ -344,8 +462,10 @@ export const TaskProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
             uploadFiles,
             waitFor,
             cancel,
+            cancelUpload,
             deleteJob,
             dismiss,
+            forgetUploaded,
             refresh,
         ]
     );

--- a/apps/frontend/src/features/player/PlayerPage.tsx
+++ b/apps/frontend/src/features/player/PlayerPage.tsx
@@ -117,22 +117,51 @@ export default function PlayerPage() {
             ) {
                 return;
             }
-            if (video || videoFileId) {
+            const clear = () => {
+                toast.error("This Video Is No Longer Available");
+                setVideo(null);
+                setVideoUrl(null);
+                setVideoFileName(null);
+                setVideoFileId(null);
+            };
+            // A device file that won't decode is convertible, so it stays
+            // loaded for the toolbar's To MP4 action.
+            if (video) {
                 setUnplayable(true);
                 return;
             }
-            toast.error("This Video Is No Longer Available");
-            setVideo(null);
-            setVideoUrl(null);
-            setVideoFileName(null);
-            setVideoFileId(null);
+            // A profile file streams from the server, so the same decode error
+            // covers two very different cases: a container this browser can't
+            // play (convertible) and a file that was deleted (gone). Asking the
+            // server which it is stops a deleted video from sitting behind a
+            // "Convert To Play" prompt that can never succeed.
+            if (videoFileId && videoUrl) {
+                void fetch(videoUrl, { method: "HEAD" })
+                    .then((res) => (res.status === 404 ? clear() : setUnplayable(true)))
+                    .catch(() => setUnplayable(true));
+                return;
+            }
+            if (videoFileId) {
+                setUnplayable(true);
+                return;
+            }
+            clear();
         };
         videoEl.addEventListener("error", onError);
         // The element may have already failed before this listener attached
         // (a fast local blob, or a source set before the effect ran).
         if (videoEl.error) onError();
         return () => videoEl.removeEventListener("error", onError);
-    }, [videoEl, video, videoFileId, setVideo, setVideoUrl, setVideoFileName, setVideoFileId]);
+    }, [
+        videoEl,
+        video,
+        videoFileId,
+        videoUrl,
+        setVideo,
+        setVideoUrl,
+        setVideoFileName,
+        setVideoFileId,
+    ]);
 
     // Restore the saved position on load; persist it on pause / source change.
     useEffect(() => {

--- a/apps/frontend/src/features/player/components/LoadMediaPopover.tsx
+++ b/apps/frontend/src/features/player/components/LoadMediaPopover.tsx
@@ -137,15 +137,19 @@ export function LoadMediaPopover({ className }: { className?: string }) {
         else loadVideo(file);
     };
 
+    // A file input fires `change` only when the picked file differs from its
+    // current value, so re-picking the same file after a reset-less pick is
+    // silently ignored and the dialog reads as unresponsive. Every path clears
+    // the value, including the ones that succeed.
     const onPickVideo = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
+        e.target.value = "";
         if (!file) return;
         // The input has no `accept` (an iOS/.mkv workaround), so it accepts any
         // file. Reject non-video picks here so Generate SRT / Convert never run
         // FFmpeg/Whisper over a text or other unrelated file.
         if (!isVideoName(file.name)) {
             toast.error("Please Select A Video File");
-            e.target.value = "";
             return;
         }
         setVideoUrl(null);
@@ -157,6 +161,7 @@ export function LoadMediaPopover({ className }: { className?: string }) {
 
     const onPickSrt = (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
+        e.target.value = "";
         if (!file) return;
         setSrt(file);
         setSrtFileName(file.name);
@@ -165,6 +170,26 @@ export function LoadMediaPopover({ className }: { className?: string }) {
 
     return (
         <div className={cn("relative", className)}>
+            {/*
+             * Mounted outside the Popover, which unmounts its children when it
+             * closes. On iOS, opening the native file sheet can dismiss the
+             * popover, and an input torn down while the sheet is still up never
+             * receives its `change` event, so the pick is silently lost and the
+             * dialog reads as unresponsive.
+             *
+             * No `accept` on the video input: iOS maps accept tokens to UTTypes
+             * and greys anything it can't map, and Matroska (.mkv) has no Apple
+             * UTType, so any video filter hides .mkv there. Leaving it open
+             * keeps every container selectable.
+             */}
+            <input ref={videoInputRef} type="file" onChange={onPickVideo} className="hidden" />
+            <input
+                ref={srtInputRef}
+                type="file"
+                accept=".srt"
+                onChange={onPickSrt}
+                className="hidden"
+            />
             <IconButton label="Load media" active={open} onClick={() => setOpen((v) => !v)}>
                 <FolderOpen size={18} />
             </IconButton>
@@ -190,25 +215,6 @@ export function LoadMediaPopover({ className }: { className?: string }) {
                         >
                             Select Subtitles
                         </Button>
-                        {/*
-                         * No `accept`: iOS maps accept tokens to UTTypes and
-                         * greys anything it can't map, and Matroska (.mkv) has
-                         * no Apple UTType, so any video filter hides .mkv on
-                         * iOS. Leaving it open keeps every container selectable.
-                         */}
-                        <input
-                            ref={videoInputRef}
-                            type="file"
-                            onChange={onPickVideo}
-                            className="hidden"
-                        />
-                        <input
-                            ref={srtInputRef}
-                            type="file"
-                            accept=".srt"
-                            onChange={onPickSrt}
-                            className="hidden"
-                        />
                     </div>
 
                     {profileId && (

--- a/apps/frontend/src/features/player/components/PlayerToolbar.tsx
+++ b/apps/frontend/src/features/player/components/PlayerToolbar.tsx
@@ -19,7 +19,9 @@ import { useState } from "react";
 import { toast } from "react-hot-toast";
 import { apiGetTemplate } from "@/shared/llm/api";
 import { ApiError, toastApiError } from "@/shared/api/errors";
+import { isUploadAborted } from "@/shared/api/client";
 import type { SubmitJobRequest } from "@/shared/jobs/types";
+import type { SubmitOptions } from "@/contexts/TaskContext";
 import { Button, IconButton, InfoTip, Popover, cn } from "@/shared/ui";
 import { useIsMobile } from "@/shared/hooks/useMediaQuery";
 import { usePlayer } from "@/contexts/PlayerContext";
@@ -118,6 +120,48 @@ export function PlayerToolbar() {
         }
     };
 
+    // Which actions are mid-submission. Tracked per action rather than as one
+    // flag so that starting "Generate SRT" on a device file does not block
+    // "To MP4": the second action joins the first action's upload instead of
+    // starting its own, which is exactly the case that used to upload twice.
+    const [pending, setPending] = useState<ReadonlySet<string>>(new Set());
+
+    const withPending = async (key: string, run: () => Promise<void>): Promise<void> => {
+        if (pending.has(key)) return;
+        setPending((prev) => new Set(prev).add(key));
+        try {
+            await run();
+        } finally {
+            setPending((prev) => {
+                const next = new Set(prev);
+                next.delete(key);
+                return next;
+            });
+        }
+    };
+
+    // Uploads a device file and submits its job, reporting the real outcome.
+    // A cancelled upload is silent (the user asked for it); a 404 means the
+    // cached profile copy was deleted, so it is named rather than shown as a
+    // generic failure.
+    const runUpload = async (
+        file: File,
+        options: SubmitOptions,
+        successMessage: string
+    ): Promise<void> => {
+        try {
+            const job = await tasks.uploadAndSubmit(file, options);
+            if (job) toast.success(successMessage);
+        } catch (err) {
+            if (isUploadAborted(err)) return;
+            if (err instanceof ApiError && err.status === 404) {
+                toast.error("That File Was Deleted From Your Profile");
+                return;
+            }
+            toastApiError(err);
+        }
+    };
+
     // Mobile -> Compact bar with the SRT actions tucked into a "More" menu
     // Desktop -> Keeps every control inline
     const isMobile = useIsMobile();
@@ -127,86 +171,96 @@ export function PlayerToolbar() {
     // A profile video is operated on by reference (no re-upload); a device
     // video is uploaded first. Either way the tray tracks it and loads the
     // result back into the player.
-    const handleGenerate = async () => {
-        if (videoFileId) {
-            const ok = await submitByRef(
-                { type: "generate_srt", file_id: videoFileId, opts: whisperOpts() },
-                () => setVideoFileId(null)
-            );
-            if (ok) toast.success("Subtitle Generation Started");
-            return;
-        }
-        if (!video) return;
-        void tasks.uploadAndSubmit(video, {
-            jobType: "generate_srt",
-            fileType: "video",
-            opts: whisperOpts(),
-        });
-        toast.success("Subtitle Generation Started");
-    };
-
-    const handleConvert = async () => {
-        if (!video && !videoFileId) return;
-        const name = (videoFileName ?? video?.name ?? "").toLowerCase();
-        if (name.endsWith(".mp4")) {
-            toast.success("Already MP4");
-            return;
-        }
-        if (videoFileId) {
-            const ok = await submitByRef(
-                { type: "convert", file_id: videoFileId, opts: convertOpts() },
-                () => setVideoFileId(null)
-            );
-            if (ok) toast.success("Conversion Started");
-            return;
-        }
-        if (!video) return;
-        void tasks.uploadAndSubmit(video, {
-            jobType: "convert",
-            fileType: "video",
-            opts: convertOpts(),
-        });
-        toast.success("Conversion Started");
-    };
-
-    const handleFixSrt = async () => {
-        if (!srt) return;
-        let template;
-        try {
-            template = await apiGetTemplate();
-        } catch (err) {
-            toastApiError(err);
-            return;
-        }
-        if (!template) {
-            toast.error("Configure An LLM Model In Your Profile To Fix Subtitles");
-            return;
-        }
-        const model = template.srt_model || template.model;
-        const sysMsg = template.srt_sys_msg || undefined;
-
-        // A known profile SRT is fixed by reference. If that file was deleted
-        // the submit 404s, so we drop the stale id and fall through to
-        // re-uploading the in-memory SRT (a locally loaded one takes that path
-        // directly, since its content lives here regardless).
-        if (srtFileId) {
-            try {
-                await tasks.submit({ type: "fix_srt", file_id: srtFileId, model, sys_msg: sysMsg });
-                toast.success("Subtitle Fix Started");
+    const handleGenerate = () =>
+        withPending("generate_srt", async () => {
+            if (videoFileId) {
+                const ok = await submitByRef(
+                    { type: "generate_srt", file_id: videoFileId, opts: whisperOpts() },
+                    () => setVideoFileId(null)
+                );
+                if (ok) toast.success("Subtitle Generation Started");
                 return;
-            } catch (err) {
-                if (!(err instanceof ApiError && err.status === 404)) {
-                    toastApiError(err);
-                    return;
-                }
-                setSrtFileId(null);
             }
-        }
-        void tasks
-            .uploadAndSubmit(srt, { jobType: "fix_srt", fileType: "srt", model, sysMsg })
-            .catch(toastApiError);
-        toast.success("Subtitle Fix Started");
-    };
+            if (!video) return;
+            // Awaited, so the toast reports what actually happened. Firing it
+            // optimistically claimed success even when the submit 404'd against
+            // a file that had since been deleted, and no task ever appeared.
+            await runUpload(
+                video,
+                { jobType: "generate_srt", fileType: "video", opts: whisperOpts() },
+                "Subtitle Generation Started"
+            );
+        });
+
+    const handleConvert = () =>
+        withPending("convert", async () => {
+            if (!video && !videoFileId) return;
+            const name = (videoFileName ?? video?.name ?? "").toLowerCase();
+            if (name.endsWith(".mp4")) {
+                toast.success("Already MP4");
+                return;
+            }
+            if (videoFileId) {
+                const ok = await submitByRef(
+                    { type: "convert", file_id: videoFileId, opts: convertOpts() },
+                    () => setVideoFileId(null)
+                );
+                if (ok) toast.success("Conversion Started");
+                return;
+            }
+            if (!video) return;
+            await runUpload(
+                video,
+                { jobType: "convert", fileType: "video", opts: convertOpts() },
+                "Conversion Started"
+            );
+        });
+
+    const handleFixSrt = () =>
+        withPending("fix_srt", async () => {
+            if (!srt) return;
+            let template;
+            try {
+                template = await apiGetTemplate();
+            } catch (err) {
+                toastApiError(err);
+                return;
+            }
+            if (!template) {
+                toast.error("Configure An LLM Model In Your Profile To Fix Subtitles");
+                return;
+            }
+            const model = template.srt_model || template.model;
+            const sysMsg = template.srt_sys_msg || undefined;
+
+            // A known profile SRT is fixed by reference. If that file was
+            // deleted the submit 404s, so we drop the stale id and fall through
+            // to re-uploading the in-memory SRT (a locally loaded one takes that
+            // path directly, since its content lives here regardless).
+            if (srtFileId) {
+                try {
+                    await tasks.submit({
+                        type: "fix_srt",
+                        file_id: srtFileId,
+                        model,
+                        sys_msg: sysMsg,
+                    });
+                    toast.success("Subtitle Fix Started");
+                    return;
+                } catch (err) {
+                    if (!(err instanceof ApiError && err.status === 404)) {
+                        toastApiError(err);
+                        return;
+                    }
+                    setSrtFileId(null);
+                }
+            }
+            await runUpload(
+                srt,
+                { jobType: "fix_srt", fileType: "srt", model, sysMsg },
+                "Subtitle Fix Started"
+            );
+        });
 
     const furiganaButton = (
         <button
@@ -229,7 +283,9 @@ export function PlayerToolbar() {
     );
 
     // Shared once so that the desktop row and the mobile
-    // "More" menu render the same buttons (full width inside the menu)
+    // "More" menu render the same buttons (full width inside the menu).
+    // Disabled while a submission is in flight so a second click can't fire
+    // before the first has registered its upload.
     const actionButtons = (
         <>
             <Button
@@ -237,7 +293,7 @@ export function PlayerToolbar() {
                 size="sm"
                 className={isMobile ? "w-full" : undefined}
                 onClick={handleGenerate}
-                disabled={!video && !videoFileId}
+                disabled={pending.has("generate_srt") || (!video && !videoFileId)}
                 title="Transcribe Audio Into Subtitles Using Whisper"
             >
                 <FileText size={15} /> Generate SRT
@@ -247,7 +303,7 @@ export function PlayerToolbar() {
                 size="sm"
                 className={isMobile ? "w-full" : undefined}
                 onClick={handleConvert}
-                disabled={!video && !videoFileId}
+                disabled={pending.has("convert") || (!video && !videoFileId)}
                 title="Convert Video To MP4 Using FFMPEG"
             >
                 <Clapperboard size={15} /> To MP4
@@ -257,7 +313,7 @@ export function PlayerToolbar() {
                 size="sm"
                 className={isMobile ? "w-full" : undefined}
                 onClick={handleFixSrt}
-                disabled={!srt}
+                disabled={pending.has("fix_srt") || !srt}
                 title="Improve Subtitles With An LLM"
             >
                 <Sparkles size={15} /> Fix SRT

--- a/apps/frontend/src/features/player/components/VideoStage.tsx
+++ b/apps/frontend/src/features/player/components/VideoStage.tsx
@@ -62,6 +62,7 @@ export function VideoStage({
             className="h-full w-full"
             onVideoEl={handleVideoEl}
             keyboardControls
+            tapToSeek
             overlay={({ controlsShown }) => {
                 // Anchor the overlay to the painted frame when known, else the
                 // element box. While the controls are shown, lift the subtitle

--- a/apps/frontend/src/features/profile/components/FilesPanel.tsx
+++ b/apps/frontend/src/features/profile/components/FilesPanel.tsx
@@ -29,6 +29,7 @@ import { usePlayer } from "@/contexts/PlayerContext";
 import { Button, Card, Checkbox, EmptyState, IconButton, Popover, cn } from "@/shared/ui";
 import { staticUrl } from "@/shared/format/files";
 import { toastApiError } from "@/shared/api/errors";
+import type { Job } from "@/shared/jobs/types";
 import { listFiles, deleteFile } from "../api";
 import { buildFileGroups, fileKind, type VideoGroup } from "../grouping";
 import type { FileOrigin, ProfileFile } from "../types";
@@ -170,23 +171,41 @@ export function FilesPanel() {
         }
     };
 
-    // Deleting a file cascades its dependent jobs away server-side. The server
-    // returns those job ids, so they are pruned from the task tray immediately
-    // (which polls only while a job is active) and the Tasks tab is refreshed.
+    // Deleting a file cascades server-side: its dependent jobs are removed, and
+    // its transcripts and clips go with it through the database's own cascades.
+    // Every affected cache is reconciled here.
+    //
+    // The jobs list is pruned through the cache directly rather than by asking
+    // SWR to revalidate it. The Files and Tasks tabs are mutually exclusive, so
+    // when this runs "jobs/history" has no mounted subscriber and a bare
+    // revalidate is a no-op, leaving the deleted job to reappear the moment the
+    // user opens the Tasks tab.
+    const reconcileAfterDelete = (fileIds: string[], jobIds: string[]) => {
+        fileIds.forEach(evictFromPlayer);
+        tasks.forgetUploaded(fileIds);
+        jobIds.forEach((jobId) => tasks.dismiss(jobId));
+        const dropped = new Set(jobIds);
+        void mutate(SWR_KEY);
+        void mutate(
+            "jobs/history",
+            (current?: Job[]) => current?.filter((j) => !dropped.has(j.id)),
+            { revalidate: true }
+        );
+        void mutate("profiles/transcripts");
+        void mutate("profiles/clips");
+    };
+
     const onDelete = async (id: string) => {
         setDeleting(id);
         try {
             const res = await deleteFile(id);
             toast.success("File Deleted");
-            evictFromPlayer(id);
             setSelected((prev) => {
                 const next = new Set(prev);
                 next.delete(id);
                 return next;
             });
-            res.deleted_job_ids.forEach((jobId) => tasks.dismiss(jobId));
-            mutate(SWR_KEY);
-            mutate("jobs/history");
+            reconcileAfterDelete([id], res.deleted_job_ids);
         } catch (e) {
             toastApiError(e);
         } finally {
@@ -199,19 +218,18 @@ export function FilesPanel() {
         if (ids.length === 0) return;
         const results = await Promise.allSettled(ids.map((id) => deleteFile(id)));
         const ok = results.filter((r) => r.status === "fulfilled").length;
-        // Prune the tray of every job cascaded away by the successful deletes,
-        // and evict any deleted file that was loaded in the player.
+        const deletedFileIds: string[] = [];
+        const deletedJobIds: string[] = [];
         results.forEach((r, i) => {
             if (r.status === "fulfilled") {
-                evictFromPlayer(ids[i]);
-                r.value.deleted_job_ids.forEach((jobId) => tasks.dismiss(jobId));
+                deletedFileIds.push(ids[i]);
+                deletedJobIds.push(...r.value.deleted_job_ids);
             }
         });
         clearSelection();
         if (ok > 0) toast.success(`Deleted ${ok} File(s)`);
         if (ok < ids.length) toast.error(`${ids.length - ok} File(s) Could Not Be Deleted`);
-        mutate(SWR_KEY);
-        mutate("jobs/history");
+        reconcileAfterDelete(deletedFileIds, deletedJobIds);
     };
 
     // Library uploads run through the task tray (which shows their progress).

--- a/apps/frontend/src/features/profile/components/TasksPanel.tsx
+++ b/apps/frontend/src/features/profile/components/TasksPanel.tsx
@@ -224,12 +224,20 @@ export function TasksPanel() {
     }, [liveJobs]);
 
     const onDelete = async (id: string) => {
+        // The row is dropped from the cache before the request settles, so a
+        // task the server has already removed (deleting a file cascades its
+        // jobs away) disappears instead of 404ing on every click with no way
+        // to clear it. `deleteJob` treats a 404 as success for the same reason.
+        void mutate("jobs/history", (current?: Job[]) => current?.filter((j) => j.id !== id), {
+            revalidate: false,
+        });
         try {
             await deleteJob(id);
-            void mutate("jobs/history");
             toast.success("Task Deleted");
         } catch (e) {
             toastApiError(e);
+        } finally {
+            void mutate("jobs/history");
         }
     };
 

--- a/apps/frontend/src/features/transcribe/TranscribePage.tsx
+++ b/apps/frontend/src/features/transcribe/TranscribePage.tsx
@@ -3,7 +3,7 @@
  * it (clickable furigana), and optionally get an LLM sentence explanation.
  */
 
-import { useRef, useState, useLayoutEffect, ChangeEvent } from "react";
+import { useEffect, useRef, useState, useLayoutEffect, ChangeEvent } from "react";
 import { toast } from "react-hot-toast";
 import { Mic, Square, Upload, Trash2, Send } from "lucide-react";
 import { apiTokenize } from "@/shared/dict/api";
@@ -43,6 +43,40 @@ export default function TranscribePage() {
     const chatEndRef = useRef<HTMLDivElement | null>(null);
     const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+    // Every blob URL minted here, so none outlives the page. Each one pins its
+    // whole audio blob in memory until revoked, and on iOS a handful of
+    // unreleased recordings is enough to make the browser start refusing work.
+    const objectUrlsRef = useRef<Set<string>>(new Set());
+    // URLs handed to a chat message, which renders them for the rest of the
+    // session. Those are owned by the message and must survive a preview swap.
+    const retainedUrlsRef = useRef<Set<string>>(new Set());
+
+    useEffect(
+        () => () => {
+            for (const url of objectUrlsRef.current) URL.revokeObjectURL(url);
+            objectUrlsRef.current.clear();
+        },
+        []
+    );
+
+    /**
+     * Points the preview at `file`, releasing the previous URL unless a chat
+     * message is still rendering it.
+     */
+    const replacePreview = (file: File | null) => {
+        if (previewUrl && !retainedUrlsRef.current.has(previewUrl)) {
+            URL.revokeObjectURL(previewUrl);
+            objectUrlsRef.current.delete(previewUrl);
+        }
+        if (!file) {
+            setPreviewUrl("");
+            return;
+        }
+        const url = URL.createObjectURL(file);
+        objectUrlsRef.current.add(url);
+        setPreviewUrl(url);
+    };
+
     useLayoutEffect(() => {
         chatEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }, [messages]);
@@ -79,8 +113,11 @@ export default function TranscribePage() {
                 let ext = mimeType.split(/[/;]+/)[1] || "ogg";
                 if (ext === "opus") ext = "webm";
                 const file = new File([blob], `recording.${ext}`, { type: mimeType });
+                // The chunks are now inside `blob`, so holding them would keep
+                // a second full copy of the recording alive.
+                chunksRef.current = [];
                 setRecordedFile(file);
-                setPreviewUrl(URL.createObjectURL(file));
+                replacePreview(file);
                 if (mediaStreamRef.current) {
                     mediaStreamRef.current.getTracks().forEach((t) => t.stop());
                     mediaStreamRef.current = null;
@@ -110,7 +147,7 @@ export default function TranscribePage() {
     const deleteMedia = () => {
         setRecordedFile(null);
         setUploadedFile(null);
-        setPreviewUrl("");
+        replacePreview(null);
         if (fileInputRef.current) fileInputRef.current.value = "";
         if (mediaStreamRef.current) {
             mediaStreamRef.current.getTracks().forEach((t) => t.stop());
@@ -120,10 +157,13 @@ export default function TranscribePage() {
 
     const handleFileUpload = (event: ChangeEvent<HTMLInputElement>) => {
         const file = event.target.files?.[0];
+        // Cleared even on a successful pick, otherwise choosing the same file
+        // again fires no `change` event and the dialog looks unresponsive.
+        event.target.value = "";
         if (file) {
             setUploadedFile(file);
             setRecordedFile(null);
-            setPreviewUrl(URL.createObjectURL(file));
+            replacePreview(file);
         }
     };
 
@@ -135,6 +175,10 @@ export default function TranscribePage() {
         const loaderId = `loader-${Date.now()}`;
         const userMessageId = `user-${Date.now() + 1}`;
 
+        // The chat bubble renders this URL for the rest of the session, so
+        // ownership passes to the message and a later preview swap must not
+        // revoke it out from under the bubble.
+        if (previewUrl) retainedUrlsRef.current.add(previewUrl);
         setMessages((prev) => [
             ...prev,
             { id: userMessageId, type: "user", audioUrl: previewUrl, isAudioMessage: true },

--- a/apps/frontend/src/shared/api/client.ts
+++ b/apps/frontend/src/shared/api/client.ts
@@ -99,17 +99,36 @@ export async function apiFetch<T = unknown>(url: string, opts: RequestInit = {})
 }
 
 /**
+ * The `ApiError` code reported when an upload is cancelled by the caller.
+ *
+ * Distinguishes a deliberate cancel from a genuine failure, so the tray drops
+ * the row instead of showing it as an error.
+ */
+export const UPLOAD_ABORTED_CODE = "UploadAborted";
+
+/**
+ * Whether an error is an upload the caller cancelled, rather than a failure.
+ *
+ * @param {unknown} error The caught error.
+ * @returns {boolean} `true` when the upload was aborted deliberately.
+ */
+export function isUploadAborted(error: unknown): boolean {
+    return error instanceof ApiError && error.code === UPLOAD_ABORTED_CODE;
+}
+
+/**
  * Wires the shared progress + completion handling for an upload `XMLHttpRequest`
  * (progress events, the 2xx/JSON-parse success path, the structured-error path,
- * and the unreachable-server path), so the upload helpers only differ in how
- * they build and send the request.
+ * the unreachable-server path, and the caller-cancelled path), so the upload
+ * helpers only differ in how they build and send the request.
  */
 function settleUpload<T>(
     xhr: XMLHttpRequest,
     resolve: (value: T) => void,
     reject: (reason: ApiError) => void,
     onProgress: (percent: number) => void,
-    onUploadComplete: () => void
+    onUploadComplete: () => void,
+    signal?: AbortSignal
 ): void {
     xhr.upload.onprogress = (event) => {
         if (event.lengthComputable) {
@@ -141,6 +160,23 @@ function settleUpload<T>(
         reject(
             new ApiError(0, "Could not reach the server", "BackendUnreachable", undefined, false)
         );
+
+    // Without this, calling `abort()` fires `onabort` (never `onerror`) and the
+    // promise would stay pending forever.
+    xhr.onabort = () =>
+        reject(new ApiError(0, "Upload Cancelled", UPLOAD_ABORTED_CODE, undefined, false));
+
+    if (signal) {
+        if (signal.aborted) {
+            xhr.abort();
+            return;
+        }
+        const onAbort = () => xhr.abort();
+        signal.addEventListener("abort", onAbort, { once: true });
+        // Detach once the request settles, so a long-lived controller does not
+        // retain the xhr after it is done.
+        xhr.onloadend = () => signal.removeEventListener("abort", onAbort);
+    }
 }
 
 /**
@@ -153,6 +189,8 @@ function settleUpload<T>(
  * @param {Record<string, string>} headers Additional request headers.
  * @param {(percent: number) => void} onProgress Upload progress callback.
  * @param {() => void} onUploadComplete Called when the upload hits 100%.
+ * @param {AbortSignal} [signal] Cancels the upload when aborted, rejecting with
+ *   an {@link ApiError} carrying {@link UPLOAD_ABORTED_CODE}.
  * @returns {Promise<T>} The parsed JSON response.
  */
 export async function uploadFile<T = unknown>(
@@ -160,7 +198,8 @@ export async function uploadFile<T = unknown>(
     url: string,
     headers: Record<string, string>,
     onProgress: (percent: number) => void,
-    onUploadComplete: () => void
+    onUploadComplete: () => void,
+    signal?: AbortSignal
 ): Promise<T> {
     return new Promise((resolve, reject) => {
         const fullUrl = url.startsWith("http") ? url : `${API_BASE}/${url}`;
@@ -182,7 +221,7 @@ export async function uploadFile<T = unknown>(
             xhr.setRequestHeader(key, headers[key]);
         }
 
-        settleUpload(xhr, resolve, reject, onProgress, onUploadComplete);
+        settleUpload(xhr, resolve, reject, onProgress, onUploadComplete, signal);
         xhr.send(file);
     });
 }
@@ -199,13 +238,16 @@ export async function uploadFile<T = unknown>(
  * @param {FormData} formData The multipart payload (file part + fields).
  * @param {(percent: number) => void} onProgress Upload progress callback.
  * @param {() => void} onUploadComplete Called when the upload hits 100%.
+ * @param {AbortSignal} [signal] Cancels the upload when aborted, rejecting with
+ *   an {@link ApiError} carrying {@link UPLOAD_ABORTED_CODE}.
  * @returns {Promise<T>} The parsed JSON response.
  */
 export async function uploadFormData<T = unknown>(
     url: string,
     formData: FormData,
     onProgress: (percent: number) => void,
-    onUploadComplete: () => void
+    onUploadComplete: () => void,
+    signal?: AbortSignal
 ): Promise<T> {
     return new Promise((resolve, reject) => {
         const fullUrl = url.startsWith("http") ? url : `${API_BASE}/${url}`;
@@ -218,7 +260,7 @@ export async function uploadFormData<T = unknown>(
         xhr.open("POST", fullUrl, true);
         xhr.setRequestHeader("X-Profile-ID", profileId);
 
-        settleUpload(xhr, resolve, reject, onProgress, onUploadComplete);
+        settleUpload(xhr, resolve, reject, onProgress, onUploadComplete, signal);
         xhr.send(formData);
     });
 }

--- a/apps/frontend/src/shared/components/VideoControls.tsx
+++ b/apps/frontend/src/shared/components/VideoControls.tsx
@@ -42,7 +42,14 @@ export function VideoControls({ video, visible }: VideoControlsProps) {
     useEffect(() => {
         if (!video) return;
         const onTime = () => setCurrent(video.currentTime);
-        const onMeta = () => setDuration(Number.isFinite(video.duration) ? video.duration : 0);
+        // A stream whose container carries no duration reports Infinity until
+        // the browser has read it all, so keep the last known good value rather
+        // than zeroing it (max={0} freezes the scrubber, see `AudioPlayer`).
+        const onMeta = () => {
+            if (Number.isFinite(video.duration) && video.duration > 0) {
+                setDuration(video.duration);
+            }
+        };
         const onPlay = () => setPlaying(true);
         const onPause = () => setPlaying(false);
         const onVol = () => {
@@ -60,6 +67,7 @@ export function VideoControls({ video, visible }: VideoControlsProps) {
 
         video.addEventListener("timeupdate", onTime);
         video.addEventListener("loadedmetadata", onMeta);
+        video.addEventListener("durationchange", onMeta);
         video.addEventListener("play", onPlay);
         video.addEventListener("pause", onPause);
         video.addEventListener("volumechange", onVol);
@@ -67,6 +75,7 @@ export function VideoControls({ video, visible }: VideoControlsProps) {
         return () => {
             video.removeEventListener("timeupdate", onTime);
             video.removeEventListener("loadedmetadata", onMeta);
+            video.removeEventListener("durationchange", onMeta);
             video.removeEventListener("play", onPlay);
             video.removeEventListener("pause", onPause);
             video.removeEventListener("volumechange", onVol);

--- a/apps/frontend/src/shared/components/VideoPlayer.tsx
+++ b/apps/frontend/src/shared/components/VideoPlayer.tsx
@@ -10,6 +10,17 @@ import { type ReactNode, useCallback, useEffect, useRef, useState } from "react"
 import { cn } from "@/shared/ui";
 import { VideoControls } from "./VideoControls";
 
+/** How far the arrow keys and the double-tap zones skip, in seconds. */
+const SKIP_SECONDS = 5;
+
+/**
+ * How long to wait for a second tap before treating the first as a plain click.
+ *
+ * Roughly the platform double-click threshold: long enough that a real double
+ * tap is never split, short enough that play/pause still feels immediate.
+ */
+const DOUBLE_TAP_MS = 250;
+
 /** Context passed to a {@link VideoPlayerProps.overlay} render function. */
 export interface VideoPlayerOverlayContext {
     /** Whether the control bar is currently shown (overlays lift above it). */
@@ -28,6 +39,13 @@ export interface VideoPlayerProps {
     onVideoEl?: (el: HTMLVideoElement | null) => void;
     /** Toggle play/pause on the spacebar (for the primary, on-page player). */
     keyboardControls?: boolean;
+    /**
+     * Skip 5s by double-tapping the left / right edge of the video.
+     *
+     * Off by default so a small embedded preview (a clip) keeps a plain
+     * click-to-toggle with no tap-detection delay.
+     */
+    tapToSeek?: boolean;
     /** Renders an overlay above the video (e.g. subtitles). */
     overlay?: (ctx: VideoPlayerOverlayContext) => ReactNode;
 }
@@ -45,6 +63,7 @@ export function VideoPlayer({
     crossOrigin,
     onVideoEl,
     keyboardControls = false,
+    tapToSeek = false,
     overlay,
 }: VideoPlayerProps) {
     const [el, setEl] = useState<HTMLVideoElement | null>(null);
@@ -74,12 +93,22 @@ export function VideoPlayer({
         };
     }, [el]);
 
+    // Seeks by `delta` seconds, clamped to the media. Shared by the arrow keys
+    // and the double-tap zones so both skip by exactly the same amount.
+    const seekBy = useCallback(
+        (delta: number) => {
+            if (!el) return;
+            const duration = Number.isFinite(el.duration) ? el.duration : Infinity;
+            el.currentTime = Math.min(Math.max(el.currentTime + delta, 0), duration);
+        },
+        [el]
+    );
+
     // Keyboard controls for the primary, on-page player: the spacebar toggles
     // play/pause and the arrows skip by 5s. Ignored while typing so they never
     // hijack a form control.
     useEffect(() => {
         if (!el || !keyboardControls) return;
-        const SKIP_SECONDS = 5;
         const onKey = (e: KeyboardEvent) => {
             const target = e.target as HTMLElement | null;
             if (
@@ -97,14 +126,12 @@ export function VideoPlayer({
                 else el.pause();
             } else if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
                 e.preventDefault();
-                const duration = Number.isFinite(el.duration) ? el.duration : Infinity;
-                const delta = e.key === "ArrowRight" ? SKIP_SECONDS : -SKIP_SECONDS;
-                el.currentTime = Math.min(Math.max(el.currentTime + delta, 0), duration);
+                seekBy(e.key === "ArrowRight" ? SKIP_SECONDS : -SKIP_SECONDS);
             }
         };
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);
-    }, [el, keyboardControls]);
+    }, [el, keyboardControls, seekBy]);
 
     const revealControls = () => {
         setControlsVisible(true);
@@ -116,6 +143,26 @@ export function VideoPlayer({
         if (!el) return;
         if (el.paused) el.play().catch(() => undefined);
         else el.pause();
+    };
+
+    // A single tap toggles play/pause and a double tap seeks, so the first tap
+    // has to wait to find out which it was. Without the delay a double tap
+    // would toggle twice on its way to seeking.
+    const tapRef = useRef<number | undefined>(undefined);
+    useEffect(() => () => window.clearTimeout(tapRef.current), []);
+
+    const onZoneClick = (direction: -1 | 1) => {
+        revealControls();
+        if (tapRef.current !== undefined) {
+            window.clearTimeout(tapRef.current);
+            tapRef.current = undefined;
+            seekBy(direction * SKIP_SECONDS);
+            return;
+        }
+        tapRef.current = window.setTimeout(() => {
+            tapRef.current = undefined;
+            togglePlay();
+        }, DOUBLE_TAP_MS);
     };
 
     const controlsShown = controlsVisible || paused;
@@ -132,10 +179,30 @@ export function VideoPlayer({
                 src={src ?? undefined}
                 playsInline
                 crossOrigin={crossOrigin}
-                onClick={togglePlay}
+                onClick={tapToSeek ? undefined : togglePlay}
                 {...{ "webkit-playsinline": "true" }}
                 className="h-full w-full object-contain focus:outline-none"
             />
+            {tapToSeek && (
+                // Sits below the overlay so a subtitle token still takes its own
+                // tap, and stops short of the control bar so scrubbing is not
+                // swallowed. `touch-action: manipulation` suppresses iOS's
+                // double-tap-to-zoom, which would otherwise eat the second tap.
+                <div className="absolute inset-x-0 bottom-[88px] top-0 flex touch-manipulation">
+                    <button
+                        type="button"
+                        aria-label={`Back ${SKIP_SECONDS} Seconds`}
+                        className="h-full flex-1 cursor-default focus:outline-none"
+                        onClick={() => onZoneClick(-1)}
+                    />
+                    <button
+                        type="button"
+                        aria-label={`Forward ${SKIP_SECONDS} Seconds`}
+                        className="h-full flex-1 cursor-default focus:outline-none"
+                        onClick={() => onZoneClick(1)}
+                    />
+                </div>
+            )}
             {overlay?.({ controlsShown })}
             <VideoControls video={el} visible={controlsShown} />
         </div>

--- a/apps/frontend/src/shared/jobs/api.ts
+++ b/apps/frontend/src/shared/jobs/api.ts
@@ -84,6 +84,7 @@ export async function deleteJob(id: string): Promise<void> {
  * @param {(percent: number) => void} onProgress Upload progress callback.
  * @param {() => void} onComplete Called when the upload hits 100%.
  * @param {string | undefined} folder Optional group label (e.g. a folder name).
+ * @param {AbortSignal} [signal] Cancels the upload when aborted.
  * @returns {Promise<UploadedFile>} The stored file.
  */
 export function uploadProfileFile(
@@ -91,12 +92,13 @@ export function uploadProfileFile(
     type: string | undefined,
     onProgress: (percent: number) => void,
     onComplete: () => void,
-    folder?: string
+    folder?: string,
+    signal?: AbortSignal
 ): Promise<UploadedFile> {
     const params = new URLSearchParams();
     if (type) params.set("type", type);
     if (folder) params.set("folder", folder);
     const query = params.toString();
     const url = query ? `profiles/files?${query}` : "profiles/files";
-    return uploadFile<UploadedFile>(file, url, {}, onProgress, onComplete);
+    return uploadFile<UploadedFile>(file, url, {}, onProgress, onComplete, signal);
 }

--- a/apps/frontend/src/shared/ui/AudioPlayer.tsx
+++ b/apps/frontend/src/shared/ui/AudioPlayer.tsx
@@ -30,35 +30,56 @@ export function AudioPlayer({ src, className }: AudioPlayerProps) {
         const a = ref.current;
         if (!a) return;
         const onTime = () => setCurrent(a.currentTime);
-        const onMeta = () => setDuration(Number.isFinite(a.duration) ? a.duration : 0);
+        // A recording captured by MediaRecorder carries no duration in its
+        // WebM header, so `a.duration` is Infinity until the browser has read
+        // the whole stream. Storing 0 for that pinned the range input at
+        // max={0}, which froze the thumb and showed 0:00 for the length.
+        // `durationchange` is the only event that fires when the real duration
+        // is finally known, so it has to be listened for as well.
+        const onMeta = () => {
+            if (Number.isFinite(a.duration) && a.duration > 0) setDuration(a.duration);
+        };
         const onEnd = () => setPlaying(false);
         const onPlay = () => setPlaying(true);
         const onPause = () => setPlaying(false);
         a.addEventListener("timeupdate", onTime);
         a.addEventListener("loadedmetadata", onMeta);
+        a.addEventListener("durationchange", onMeta);
         a.addEventListener("ended", onEnd);
         a.addEventListener("play", onPlay);
         a.addEventListener("pause", onPause);
+        // Metadata can already be loaded by the time this effect runs, in which
+        // case neither event fires again and the duration would be lost.
+        if (a.readyState >= 1) onMeta();
         return () => {
             a.removeEventListener("timeupdate", onTime);
             a.removeEventListener("loadedmetadata", onMeta);
+            a.removeEventListener("durationchange", onMeta);
             a.removeEventListener("ended", onEnd);
             a.removeEventListener("play", onPlay);
             a.removeEventListener("pause", onPause);
         };
     }, []);
 
-    // Reset when the source changes.
+    // Reset when the source changes. The duration is reset too, otherwise a new
+    // clip inherits the previous one's length until its own metadata arrives.
     useEffect(() => {
         setCurrent(0);
+        setDuration(0);
         setPlaying(false);
     }, [src]);
 
     const toggle = () => {
         const a = ref.current;
         if (!a) return;
-        if (a.paused) a.play().catch(() => undefined);
-        else a.pause();
+        if (a.paused) {
+            // iOS ignores `preload="metadata"` on cellular and in low-power
+            // mode, so the duration can still be unknown at this point. The
+            // play gesture is the one moment loading is guaranteed to be
+            // allowed, so nudge it then.
+            if (!duration && a.readyState === 0) a.load();
+            a.play().catch(() => undefined);
+        } else a.pause();
     };
 
     const onSeek = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/apps/mirumoji/pyproject.toml
+++ b/apps/mirumoji/pyproject.toml
@@ -140,6 +140,7 @@ indent-width = 4
 [tool.ruff.lint]
 select = [
     "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
     "F",   # pyflakes
     "I",   # isort
     "B",   # flake8-bugbear
@@ -152,6 +153,8 @@ select = [
 [tool.ruff.format]
 quote-style = "double"
 indent-style = "space"
+docstring-code-format = true
+docstring-code-line-length = 79
 
 # --- MyPy ---
 [tool.mypy]

--- a/apps/mirumoji/pyproject.toml
+++ b/apps/mirumoji/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mirumoji"
-version = "3.6.0"
+version = "3.7.0"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "Self-Hostable Japanese Language Immersion Tool"

--- a/apps/mirumoji/src/mirumoji/__init__.py
+++ b/apps/mirumoji/src/mirumoji/__init__.py
@@ -7,4 +7,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("mirumoji")
 except PackageNotFoundError:
-    __version__ = "3.6.0"
+    __version__ = "3.7.0"

--- a/apps/mirumoji/src/mirumoji/exceptions.py
+++ b/apps/mirumoji/src/mirumoji/exceptions.py
@@ -290,9 +290,16 @@ class DatabaseError(MirumojiServerError):
     code: ClassVar[str] = "Database"
 
 
-class RecordNotFoundError(DatabaseError):
+class RecordNotFoundError(MirumojiServerError):
     """
     Raised when a requested database record does not exist
+
+    info: Not A `DatabaseError`
+        - A missing row is an expected client condition (a stale id, a record
+          another request already deleted), not a storage failure
+        - Keeping it off `DatabaseError` lets callers and the `UnitOfWork` tell
+          "the row is not there" apart from "the database broke", which decides
+          whether the failure is logged as a crash with a traceback
     """
 
     http_status: ClassVar[int] = 404

--- a/apps/mirumoji/src/mirumoji/launcher/cli/commands.py
+++ b/apps/mirumoji/src/mirumoji/launcher/cli/commands.py
@@ -39,6 +39,7 @@ from ..modal import lifecycle as modal_lifecycle
 from ..modal.constants import (
     DATA_VOLUME_NAME,
     HOST_APP_NAME,
+    MODAL_LOGS_MAX_TAIL,
     WEB_FUNCTION_NAME,
     WEB_PASSWORD_ENV,
     WEB_USERNAME,
@@ -1429,7 +1430,12 @@ def modal_logs(
         typer.Option(
             "--tail",
             "-n",
-            help="How Many Recent Log Entries To Fetch",
+            "-t",
+            min=1,
+            max=MODAL_LOGS_MAX_TAIL,
+            help=(
+                "How Many Recent Log Entries To Fetch (Ignored With --follow)"
+            ),
         ),
     ] = 100,
     follow: Annotated[
@@ -1446,6 +1452,9 @@ def modal_logs(
 
     Fetches the most recent host log entries, or live-streams them with
     `--follow`. Useful for diagnosing a deploy or a failing job on the host
+
+    A followed stream starts from the newest entries, so `--tail` only applies
+    to a one-shot fetch
     """
     env = envfile.resolve_managed_config(HOST_CONFIG_FILE)
 

--- a/apps/mirumoji/src/mirumoji/launcher/core/envfile.py
+++ b/apps/mirumoji/src/mirumoji/launcher/core/envfile.py
@@ -66,7 +66,6 @@ def overlay_environ(
 
     Example:
         ```python
-
         values = {"VAR_0": "0", "VAR_1": "V1A", "VAR_2": "V2"}
         names = ["VAR_1", "VAR_2", "VAR_3"]
 

--- a/apps/mirumoji/src/mirumoji/launcher/gui/app.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/app.py
@@ -109,10 +109,11 @@ def _page_main(page: ft.Page) -> None:
                 panels[3] = logs.build(page, state)
             else:
                 panels[4] = modal_host.build(page, state)
-        # The Dashboard pills reflect the persisted deployment choice, which
-        # Settings can change. Re-read it from the config each time it's shown
-        if index == 0 and state.sync_dashboard is not None:
-            state.sync_dashboard()
+        # A panel is built once and cached, so anything it renders from the
+        # managed config (the Dashboard's deployment pills, the Modal Host's
+        # mode pills) goes stale as soon as Settings changes it. Re-read it
+        # each time the panel is shown
+        state.sync_panel(index)
         body.content = panels[index]
         page.update()
 

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/dashboard.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/dashboard.py
@@ -28,6 +28,11 @@ from .. import theme
 from ..runner import run_blocking, run_stream
 from ..state import AppState
 
+PANEL_INDEX = 0
+"""
+This panel's navigation index, which its refresh callback registers under
+"""
+
 # --- Types ---
 
 _CUSTOM_BUTTON: TypeAlias = (
@@ -369,7 +374,7 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
             ft.Text, version_pill.content
         ).value = envfile.resolve_image_version(state.env_path)
 
-    state.sync_dashboard = sync_dashboard
+    state.register_sync(PANEL_INDEX, sync_dashboard)
 
     return ft.Column(
         expand=True,

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/logs.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/logs.py
@@ -9,7 +9,6 @@ from collections.abc import Generator
 
 import flet as ft
 
-from ....exceptions import ModalError
 from ....paths import HOST_CONFIG_FILE
 from ...core import envfile, lifecycle, process
 from ...core.compose import RESOLVED_COMPOSE_PATH
@@ -52,7 +51,7 @@ def _modal_logs(
         tail (int | None): How many recent entries to fetch, or `None` for the
             default
         follow (bool): Live-follow instead of fetching recent entries
-        handle (StreamHandle): Cancellation token for the followed stream
+        handle (StreamHandle): Cancellation token for the stream
 
     Yields:
         The log lines
@@ -63,20 +62,15 @@ def _modal_logs(
     env = envfile.resolve_managed_config(HOST_CONFIG_FILE)
     entries = min(tail or 100, MODAL_LOGS_MAX_TAIL)
     with modal_lifecycle.modal_credentials(env):
-        if not follow:
-            output = modal_lifecycle.fetch_app_logs(HOST_APP_NAME, entries)
-            yield from (output.rstrip("\n").splitlines() or ["No Log Entries"])
-            return
-        if not modal_lifecycle.modal_cli_available():
-            raise ModalError(
-                "Following Modal Logs Needs A Python Interpreter On This "
-                "Machine. Untick Follow To Fetch Recent Entries Instead"
-            )
-        # `check=False` because cancelling a followed stream kills the process,
-        # which then exits non-zero through no fault of its own
+        # Both modes go through the same stream. A fetch exits on its own once
+        # it has printed its entries, so it needs no separate path, and the
+        # lines land in the terminal as they arrive rather than in one block
+        #
+        # `check=False` because cancelling kills the process, which then exits
+        # non-zero through no fault of its own
         yield from process.stream(
             modal_lifecycle.app_logs_command(
-                HOST_APP_NAME, follow=True, tail=entries
+                HOST_APP_NAME, follow=follow, tail=entries
             ),
             check=False,
             handle=handle,

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/logs.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/logs.py
@@ -1,20 +1,86 @@
 """
 Defines the Logs panel
 
-Streams Docker Compose container logs for the whole stack or a single service
+Streams Docker Compose container logs for the whole stack or a single service,
+or the Modal-hosted app's logs when the host is deployed
 """
+
+from collections.abc import Generator
 
 import flet as ft
 
-from ...core import lifecycle
+from ....exceptions import ModalError
+from ....paths import HOST_CONFIG_FILE
+from ...core import envfile, lifecycle, process
 from ...core.compose import RESOLVED_COMPOSE_PATH
 from ...core.constants import BACKEND_SERVICE, FRONTEND_SERVICE
 from ...core.process import StreamHandle
+from ...modal import lifecycle as modal_lifecycle
+from ...modal.constants import HOST_APP_NAME, MODAL_LOGS_MAX_TAIL
 from .. import theme
 from ..runner import run_stream
 from ..state import AppState
 
 _ALL = "all"
+
+_DOCKER_SOURCE = "Docker"
+"""
+Log source label for the local Docker Compose stack
+"""
+
+_MODAL_SOURCE = "Modal"
+"""
+Log source label for the Modal-hosted app
+"""
+
+
+def _modal_logs(
+    tail: int | None,
+    follow: bool,
+    handle: StreamHandle,
+) -> Generator[str, None, None]:
+    """
+    Streams the Modal-hosted app's logs
+
+    info: Credential Lifetime
+        `modal_credentials` mutates `os.environ` for the duration of its block,
+        and the caller consumes this generator lazily on a worker thread. The
+        block is therefore opened inside the generator, so the credentials are
+        still in place when the process is actually spawned
+
+    Args:
+        tail (int | None): How many recent entries to fetch, or `None` for the
+            default
+        follow (bool): Live-follow instead of fetching recent entries
+        handle (StreamHandle): Cancellation token for the followed stream
+
+    Yields:
+        The log lines
+
+    Raises:
+        ModalError: If credentials are missing or the logs cannot be read
+    """
+    env = envfile.resolve_managed_config(HOST_CONFIG_FILE)
+    entries = min(tail or 100, MODAL_LOGS_MAX_TAIL)
+    with modal_lifecycle.modal_credentials(env):
+        if not follow:
+            output = modal_lifecycle.fetch_app_logs(HOST_APP_NAME, entries)
+            yield from (output.rstrip("\n").splitlines() or ["No Log Entries"])
+            return
+        if not modal_lifecycle.modal_cli_available():
+            raise ModalError(
+                "Following Modal Logs Needs A Python Interpreter On This "
+                "Machine. Untick Follow To Fetch Recent Entries Instead"
+            )
+        # `check=False` because cancelling a followed stream kills the process,
+        # which then exits non-zero through no fault of its own
+        yield from process.stream(
+            modal_lifecycle.app_logs_command(
+                HOST_APP_NAME, follow=True, tail=entries
+            ),
+            check=False,
+            handle=handle,
+        )
 
 
 def build(page: ft.Page, state: AppState) -> ft.Control:
@@ -39,6 +105,20 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
     tail_input = theme.SettingsInput("Tail Lines", "200")
     tail_input.width = 160
     follow_cb = ft.Checkbox(label="Follow", value=False)
+
+    def on_source_select(_: ft.Event[ft.Dropdown]) -> None:
+        # The Service picker only means anything for the compose stack, so it
+        # is disabled rather than silently ignored when reading Modal logs
+        service_dd.disabled = source_dd.dropdown.value == _MODAL_SOURCE
+        page.update()
+
+    source_dd = theme.SettingsDropdown(
+        "Source",
+        _DOCKER_SOURCE,
+        [_DOCKER_SOURCE, _MODAL_SOURCE],
+        width=180,
+    )
+    source_dd.dropdown.on_select = on_source_select
 
     def resolve_tail() -> tuple[int | None, bool]:
         """
@@ -77,6 +157,7 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
         stop_btn.disabled = False
         page.update()
 
+        on_modal = source_dd.dropdown.value == _MODAL_SOURCE
         compose_file = (
             RESOLVED_COMPOSE_PATH if RESOLVED_COMPOSE_PATH.is_file() else None
         )
@@ -85,8 +166,9 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
             if service_dd.dropdown.value == _ALL
             else service_dd.dropdown.value
         )
-        # Highlight the docker service prefix only when showing every service
-        terminal.with_service = service is None
+        # Highlight the docker service prefix only when showing every service.
+        # Modal's lines carry no service prefix at all
+        terminal.with_service = service is None and not on_modal
 
         def settle() -> None:
             """
@@ -112,19 +194,18 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
             state.notify(message, "danger")
             page.update()
 
-        run_stream(
-            page,
-            lifecycle.logs(
+        gen = (
+            _modal_logs(tail, bool(follow_cb.value), handle)
+            if on_modal
+            else lifecycle.logs(
                 service,
                 follow=bool(follow_cb.value),
                 tail=tail,
                 compose_file=compose_file,
                 handle=handle,
-            ),
-            terminal,
-            on_done=done,
-            on_error=fail,
+            )
         )
+        run_stream(page, gen, terminal, on_done=done, on_error=fail)
 
     def stop(_: ft.Event[ft.Button]) -> None:
         handle = active["handle"]
@@ -150,7 +231,8 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
         controls=[
             ft.Text("Logs", theme_style=ft.TextThemeStyle.HEADLINE_LARGE),
             ft.Text(
-                "Container Logs From The Running Docker Compose Application",
+                "Container Logs From The Running Docker Compose Application, "
+                "Or The Modal-Hosted App",
                 theme_style=ft.TextThemeStyle.BODY_MEDIUM,
             ),
             theme.Section(
@@ -160,6 +242,7 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
                     wrap=True,
                     vertical_alignment=ft.CrossAxisAlignment.END,
                     controls=[
+                        source_dd,
                         service_dd,
                         tail_input,
                         follow_cb,

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/modal_host.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/modal_host.py
@@ -31,6 +31,11 @@ from .. import theme
 from ..runner import run_blocking
 from ..state import AppState
 
+PANEL_INDEX = 4
+"""
+This panel's navigation index, which its refresh callback registers under
+"""
+
 # --- Types ---
 
 _CUSTOM_BUTTON: TypeAlias = (
@@ -127,6 +132,7 @@ def build(page: ft.Page, state: AppState) -> ft.Control:
         )
 
     _refresh_config()
+    state.register_sync(PANEL_INDEX, _refresh_config)
 
     def _ready() -> dict[str, str] | None:
         """

--- a/apps/mirumoji/src/mirumoji/launcher/gui/state.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/state.py
@@ -40,11 +40,10 @@ class AppState:
         env_path (Path): Path to the managed user configuration file (`.env`)
         env (dict[str, str]): Resolved environment variables (from `env_path`)
         busy (bool): Whether a long-running action is in progress
-        sync_dashboard (Callable[[], None] | None): The callback function
-            attached to the dashboard's configuration-display elements that
-            updates the shown configuration based on the managed user
-            configuration file whenver the dashboard is re-loaded by the main
-            page
+        panel_sync (dict[int, Callable[[], None]]): Per-panel refresh
+            callbacks, keyed by navigation index, that re-read the managed
+            user configuration into the panel's display elements whenever the
+            main page shows it again
     """
 
     notify: Callable[[str, str], None]
@@ -54,7 +53,33 @@ class AppState:
     env_path: Path = HOST_CONFIG_FILE
     env: dict[str, str] = field(default_factory=dict)
     busy: bool = False
-    sync_dashboard: Callable[[], None] | None = None
+    panel_sync: dict[int, Callable[[], None]] = field(default_factory=dict)
+
+    def register_sync(self, index: int, refresh: Callable[[], None]) -> None:
+        """
+        Registers a panel's refresh callback under its navigation index
+
+        A panel is built once and then cached, so anything it renders from the
+        managed configuration goes stale as soon as another panel changes it.
+        Registering here is what makes the main page refresh it on every visit
+
+        Args:
+            index (int): The panel's navigation index
+            refresh (Callable[[], None]): Re-reads the configuration into the
+                panel's display elements
+        """
+        self.panel_sync[index] = refresh
+
+    def sync_panel(self, index: int) -> None:
+        """
+        Runs a panel's refresh callback, if it registered one
+
+        Args:
+            index (int): The panel's navigation index
+        """
+        refresh = self.panel_sync.get(index)
+        if refresh is not None:
+            refresh()
 
     def load_deployment(self, env: Mapping[str, str]) -> None:
         """

--- a/apps/mirumoji/src/mirumoji/launcher/modal/app.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/app.py
@@ -60,12 +60,16 @@ above a normal shutdown and below `Modal`'s grace, turning a grace-period
 
 _PARTIAL_SUFFIX = ".mirumoji-partial"
 """
-Reserved suffix of an in-progress write the volume syncer skips
+Reserved marker of an in-progress write the volume syncer skips
 
 The server writes media to a uniquely named temporary sibling and
 atomically renames it into place (mirroring `server.media.PARTIAL_SUFFIX`).
-The suffix isreserved, so it never matches a real uploaded filename,
+The marker is reserved, so it never matches a real uploaded filename,
 and skipping it keeps a partially written file from reaching the volume
+
+The marker sits before the extension (`<stem>.<token>.mirumoji-partial<ext>`)
+because `FFMPEG` picks its muxer from the output's extension, so it is matched
+anywhere in the name rather than only at the end
 """
 
 _DB_FILENAME = "mirumoji.db"
@@ -272,9 +276,9 @@ def _is_partial(path: Path) -> bool:
         path (Path): The changed path
 
     Returns:
-        `True` when the name ends in the reserved partial-write suffix
+        `True` when the name carries the reserved partial-write marker
     """
-    return path.name.endswith(_PARTIAL_SUFFIX)
+    return _PARTIAL_SUFFIX in path.name
 
 
 def _is_db_file(path: Path) -> bool:
@@ -505,10 +509,10 @@ async def _volume_syncer(cache: Path, mount: Path) -> None:
                                 "While A Media File Is Pending"
                             )
                             continue
-                        if src.is_file():
-                            await _mirror(
-                                src, dest, attempts=_SYNC_COPY_ATTEMPTS
-                            )
+                        if src.is_file() and await _mirror(
+                            src, dest, attempts=_SYNC_COPY_ATTEMPTS
+                        ):
+                            LOGGER.info(f"[Volume Syncer] Copied '{rel}'")
                         continue
 
                     # A media addition or modification: its file must reach the

--- a/apps/mirumoji/src/mirumoji/launcher/modal/constants.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/constants.py
@@ -37,6 +37,15 @@ HOST_APP_NAME = "mirumoji-host"
 The deployed host app's name on the user's Modal workspace
 """
 
+MODAL_LOGS_MAX_TAIL = 20000
+"""
+The largest `--tail` the `modal app logs` CLI accepts
+
+Passing more is rejected with a usage error, so the launcher bounds its own
+option here and reports a clean message instead of surfacing modal's raw usage
+text
+"""
+
 HOST_MODE_KEY = "mirumoji-host-mode"
 """
 Modal app tag holding a digest of the host's deploy-time configuration (GPU vs

--- a/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
@@ -27,7 +27,6 @@ from ...modal import (
     deployed_tags,
     ensure_authenticated,
     modal_cli_argv,
-    modal_cli_available,
     stop,
 )
 
@@ -40,7 +39,6 @@ __all__ = [
     "download_volume",
     "ensure_volume",
     "fetch_app_logs",
-    "modal_cli_available",
     "modal_credentials",
     "stop",
     "volume_exists",

--- a/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
@@ -15,10 +15,9 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
-import sys
 from collections.abc import Iterator
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from ...exceptions import ModalError
 from ...modal import (
@@ -27,6 +26,8 @@ from ...modal import (
     clean_subprocess_error,
     deployed_tags,
     ensure_authenticated,
+    modal_cli_argv,
+    modal_cli_available,
     stop,
 )
 
@@ -39,6 +40,7 @@ __all__ = [
     "download_volume",
     "ensure_volume",
     "fetch_app_logs",
+    "modal_cli_available",
     "modal_credentials",
     "stop",
     "volume_exists",
@@ -282,14 +284,17 @@ def download_volume(name: str, destination: Path) -> None:
     """
     Downloads every file in a named `modal.Volume` into a local directory
 
-    info: CLI-Backed
-        The `Modal` SDK exposes no bulk recursive download, so this shells out
-        to `modal volume get`, which downloads the whole volume tree in one
-        pass (mirroring how `stop` shells out for an app stop)
+    info: SDK-Backed
+        - Walks the volume with `listdir(recursive=True)` and streams each file
+          out through the SDK, so nothing is spawned
+
+        - This used to shell out to `modal volume get`. In the packaged desktop
+          GUI `sys.executable` is the app binary rather than an interpreter, so
+          that spawned a second GUI window and blocked forever waiting on it
 
     info: Overwrites
-        Passes `--force`, so re-downloading into a populated directory
-        overwrites the existing copies rather than failing
+        An existing local copy is replaced, so re-downloading into a populated
+        directory refreshes it rather than failing
 
     info: Blocking
         Performs network I/O and can take a while for a large volume, so a
@@ -303,9 +308,10 @@ def download_volume(name: str, destination: Path) -> None:
         ModalError: If credentials are missing, the volume is absent, or the
             download fails
     """
+    import modal
+
     ensure_authenticated()
-    # Guard the common case with a clean message instead of the modal CLI's
-    # noisy "volume not found" stderr
+    # Guard the common case with a clean message instead of a raw SDK error
     if not volume_exists(name):
         raise ModalError(
             f"The Data Volume '{name}' Does Not Exist. Deploy The Host App "
@@ -314,30 +320,32 @@ def download_volume(name: str, destination: Path) -> None:
     LOGGER.info(f"Downloading Modal Volume '{name}' To '{destination}'")
     try:
         destination.mkdir(parents=True, exist_ok=True)
-        result = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "modal",
-                "volume",
-                "get",
-                name,
-                "/",
-                str(destination),
-                "--force",
-            ],
-            capture_output=True,
-            text=True,
-            encoding="utf-8",
-            errors="replace",
-            check=False,
-            creationflags=NO_WINDOW,
-        )
-    except (OSError, subprocess.SubprocessError) as e:
+        volume = modal.Volume.from_name(name)
+        entries = volume.listdir("/", recursive=True)
+    except Exception as e:
         raise ModalError(f"Failed To Download Volume '{name}': {e}") from e
-    if result.returncode != 0:
-        detail = clean_subprocess_error(result.stderr)
-        raise ModalError(f"Failed To Download Volume '{name}': {detail}")
+
+    copied = 0
+    for entry in entries:
+        # Directories are implied by their files, so only files are streamed
+        if getattr(entry, "type", None) == modal.types.FileEntryType.DIRECTORY:
+            continue
+        relative = PurePosixPath(entry.path.lstrip("/"))
+        target = destination / Path(*relative.parts)
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with target.open("wb") as f:
+                for chunk in volume.read_file(entry.path):
+                    f.write(chunk)
+        except Exception as e:
+            raise ModalError(
+                f"Failed To Download '{entry.path}' From Volume '{name}': {e}"
+            ) from e
+        copied += 1
+
+    LOGGER.info(
+        f"Downloaded {copied} File(s) From Volume '{name}' To '{destination}'"
+    )
 
 
 def app_logs_command(name: str, *, follow: bool, tail: int) -> list[str]:
@@ -359,16 +367,11 @@ def app_logs_command(name: str, *, follow: bool, tail: int) -> list[str]:
 
     Returns:
         The `modal app logs` argv
+
+    Raises:
+        ModalError: If there is no interpreter or `modal` executable to spawn
     """
-    argv = [
-        sys.executable,
-        "-m",
-        "modal",
-        "app",
-        "logs",
-        name,
-        "--timestamps",
-    ]
+    argv = modal_cli_argv("app", "logs", name, "--timestamps")
     if follow:
         argv.append("-f")
     else:
@@ -381,10 +384,14 @@ def fetch_app_logs(name: str, tail: int) -> str:
     Fetches the most recent log entries of a deployed Modal app
 
     info: CLI-Backed
-        The `Modal` SDK exposes no log reader, so this shells out to
-        `modal app logs`, which resolves a deployed app by name and prints its
-        recent entries (see streaming `app_logs_command(follow=True)` through
-        `launcher.core.process.stream` for the live-follow variant)
+        - The `Modal` SDK exposes no log reader, so this shells out to
+          `modal app logs`, which resolves a deployed app by name and prints
+          its recent entries (see streaming `app_logs_command(follow=True)`
+          through `launcher.core.process.stream` for the live-follow variant)
+
+        - Unlike the stop and volume paths, there is nothing in-process to fall
+          back to, so a bundle with no interpreter reports that plainly rather
+          than spawning the app binary at itself
 
     Args:
         name (str): The deployed app name
@@ -398,13 +405,21 @@ def fetch_app_logs(name: str, tail: int) -> str:
     """
     ensure_authenticated()
     try:
+        argv = app_logs_command(name, follow=False, tail=tail)
+    except ModalError as e:
+        raise ModalError(
+            f"Failed To Read Logs For '{name}': {e}. Read Them From The Modal "
+            "Dashboard Or The 'mirumoji modal logs' Command Instead"
+        ) from e
+    try:
         result = subprocess.run(
-            app_logs_command(name, follow=False, tail=tail),
+            argv,
             capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",
             check=False,
+            stdin=subprocess.DEVNULL,
             creationflags=NO_WINDOW,
         )
     except (OSError, subprocess.SubprocessError) as e:

--- a/apps/mirumoji/src/mirumoji/modal.py
+++ b/apps/mirumoji/src/mirumoji/modal.py
@@ -10,10 +10,11 @@ abstract: Server
     runs locally
 
 abstract: Launcher
-    The launcher deploys mirumoji itself as a hosted app, with both backend
-    and frontend running on Modal. Its launcher-only host operations
-    (credentials, volume management, URLs, and logs) live in
-    `launcher.modal.lifecycle`
+    - The launcher deploys mirumoji itself as a hosted app, with both backend
+      and frontend running on Modal
+
+    - Its launcher-only host operations (credentials, volume management, URLs,
+      and logs) live in `launcher.modal.lifecycle`
 
 info: Authentication
     Every call authenticates through the environment's `MODAL_TOKEN_ID` /
@@ -38,8 +39,10 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .exceptions import ModalError
@@ -64,7 +67,7 @@ Matches the ANSI colour escape codes the `modal` CLI writes to its output
 _BOX_DRAWING = "".join(chr(code) for code in range(0x2500, 0x2580))
 """
 Every character in Unicode's Box Drawing block, so the borders `Rich` frames
-the `modal` CLI's error panels with can be stripped whatever style it uses
+the `modal` CLI's error panels with can be stripped
 """
 
 _ASCII_BORDER = "+-|"
@@ -72,6 +75,88 @@ _ASCII_BORDER = "+-|"
 The ASCII characters `Rich` draws its panel borders with when it renders to a
 non-`UTF` terminal (a Windows `cp1252` console)
 """
+
+_PYTHON_STEMS = frozenset({"python", "pythonw", "python3", "pythonw3"})
+"""
+Executable names that identify `sys.executable` as a real Python interpreter
+
+question: Why
+    - The desktop GUI ships as a `flet build` bundle that embeds Python in the
+      Flutter host process, so `sys.executable` is the app binary rather than
+      an interpreter
+
+    - Spawning `sys.executable -m modal ...` there re-launches the GUI in a
+      second window that never answers, so any command that shells out has to
+      verify what it is about to run first
+"""
+
+
+def python_executable() -> str | None:
+    """
+    Returns a real Python interpreter to spawn, or `None` when there is none
+
+    info: Packaged Builds
+        - A `pip`-installed launcher runs under a genuine interpreter, so
+          `sys.executable` is used directly
+
+        - Inside a packaged bundle `sys.executable` is the app binary, so
+          `PATH` is searched instead and `None` is returned when the machine
+          has no interpreter at all
+
+    Returns:
+        A path to a Python interpreter, or `None` when none is available
+    """
+    if not getattr(sys, "frozen", False):
+        stem = Path(sys.executable).stem.lower()
+        if stem in _PYTHON_STEMS:
+            return sys.executable
+    for name in ("python3", "python"):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None
+
+
+def modal_cli_argv(*args: str) -> list[str]:
+    """
+    Builds the argv for a `modal` CLI invocation
+
+    Prefers `<interpreter> -m modal`, falling back to a `modal` entry point on
+    the `PATH` when the process has no interpreter to spawn
+
+    Args:
+        *args: The `modal` sub-command and its arguments
+
+    Returns:
+        The argv to spawn
+
+    Raises:
+        ModalError: If neither an interpreter nor a `modal` executable is found
+    """
+    interpreter = python_executable()
+    if interpreter is not None:
+        return [interpreter, "-m", "modal", *args]
+    entry_point = shutil.which("modal")
+    if entry_point is not None:
+        return [entry_point, *args]
+    raise ModalError(
+        "No Python Interpreter Or 'modal' Executable Was Found To Run The "
+        "Modal CLI With"
+    )
+
+
+def modal_cli_available() -> bool:
+    """
+    Reports whether a `modal` CLI can be spawned at all
+
+    Lets a caller offer a degraded path (a one-shot in-process read rather than
+    a live stream) instead of failing, since a packaged bundle may ship no
+    interpreter
+
+    Returns:
+        `True` when `modal_cli_argv` would succeed
+    """
+    return python_executable() is not None or shutil.which("modal") is not None
 
 
 def clean_subprocess_error(stderr: str) -> str:
@@ -257,14 +342,45 @@ def ensure_deployed(
     LOGGER.info(f"Deployed Modal App '{name}'")
 
 
+def _stop_in_process(name: str) -> None:
+    """
+    Stops a deployed `Modal` app through modal's own command callback
+
+    question: Why Not A Subprocess
+        - Modal's SDK exposes no public app-stop, and the packaged desktop GUI
+          has no interpreter to shell out with, so the CLI command's underlying
+          callback is invoked directly
+
+        - It is reached through a narrow wrapper so a modal release that moves
+          it degrades to the subprocess path instead of breaking the caller
+
+    Args:
+        name (str): The deployed app name to stop
+
+    Raises:
+        SystemExit: If modal reports the app is already stopped
+        Exception: If the stop fails or modal's command layout changed
+    """
+    from modal.cli.app import stop as stop_command
+
+    callback = stop_command.callback
+    if callback is None:
+        raise AttributeError("Modal's App-Stop Command Exposes No Callback")
+    callback(name, yes=True)
+
+
 def stop(name: str) -> str | None:
     """
     Stops a deployed `Modal` app under `name`, removing it from the workspace
 
-    info: CLI-Backed
+    info: In-Process First
         - Modal's Python SDK exposes no public call to stop an app, so this
-          shells out to the modal's CLI `modal app stop` via a subprocess
-          call
+          drives modal's own command callback in-process and falls back to
+          the `modal app stop` CLI when that is unavailable
+
+        - The packaged desktop GUI embeds Python in the app binary, so
+          `sys.executable` is not an interpreter there. Running the callback
+          in-process keeps the stop working without spawning anything
 
         - Stopping is one-way, so a stopped app is redeployed
           rather than restarted
@@ -288,17 +404,38 @@ def stop(name: str) -> str | None:
 
     LOGGER.info(f"Stopping Modal App '{name}'")
     try:
+        _stop_in_process(name)
+    except SystemExit as e:
+        # Modal exits with a message when the app is already stopped, which is
+        # the desired end state rather than a failure
+        LOGGER.info(f"Modal App '{name}' Was Already Stopped : {e}")
+        return None
+    except (ImportError, AttributeError, TypeError) as e:
+        # Modal moved or reshaped the command, so fall back to the CLI
+        LOGGER.warning(
+            f"Could Not Stop Modal App '{name}' In-Process, Falling Back To "
+            f"The Modal CLI : {e}"
+        )
+    except Exception as e:
+        message = f"Could Not Stop Modal App '{name}': {e}"
+        LOGGER.warning(message)
+        return message
+    else:
+        return None
+
+    try:
         result = subprocess.run(
-            [sys.executable, "-m", "modal", "app", "stop", name, "-y"],
+            modal_cli_argv("app", "stop", name, "-y"),
             capture_output=True,
             text=True,
             encoding="utf-8",
             errors="replace",
             timeout=30,
             check=False,
+            stdin=subprocess.DEVNULL,
             creationflags=NO_WINDOW,
         )
-    except (OSError, subprocess.SubprocessError) as e:
+    except (OSError, subprocess.SubprocessError, ModalError) as e:
         message = f"Could Not Stop Modal App '{name}': {e}"
         LOGGER.warning(message)
         return message

--- a/apps/mirumoji/src/mirumoji/modal.py
+++ b/apps/mirumoji/src/mirumoji/modal.py
@@ -145,20 +145,6 @@ def modal_cli_argv(*args: str) -> list[str]:
     )
 
 
-def modal_cli_available() -> bool:
-    """
-    Reports whether a `modal` CLI can be spawned at all
-
-    Lets a caller offer a degraded path (a one-shot in-process read rather than
-    a live stream) instead of failing, since a packaged bundle may ship no
-    interpreter
-
-    Returns:
-        `True` when `modal_cli_argv` would succeed
-    """
-    return python_executable() is not None or shutil.which("modal") is not None
-
-
 def clean_subprocess_error(stderr: str) -> str:
     """
     Distils the `modal` CLI's noisy error output down to one readable line

--- a/apps/mirumoji/src/mirumoji/server/db/__init__.py
+++ b/apps/mirumoji/src/mirumoji/server/db/__init__.py
@@ -170,6 +170,18 @@ class UnitOfWork:
         an exception occurred within the context block. Always closes the
         active database session
 
+        info: Expected Conditions Are Not Crashes
+            - A missing row is an ordinary client condition, so logging it as
+              a failed transaction with a full traceback buried real failures
+              in noise (a stale id in the UI produced an `ERROR` per click)
+
+            - Domain exceptions already carry their severity in
+              `MirumojiServerError.http_status`, so anything below `500` is
+              logged as a warning without a traceback, while a genuine failure
+              keeps the `ERROR` and its traceback
+
+            - The rollback is unconditional either way
+
         Args:
             exc_type: The exception class, if an error was raised
             exc_val: The exception instance, if an error was raised
@@ -177,9 +189,15 @@ class UnitOfWork:
         """
 
         if exc_type is not None:
-            LOGGER.exception(
-                "Database Transaction Failed - Rolling Back",
-            )
+            status = getattr(exc_val, "http_status", None)
+            if isinstance(status, int) and status < 500:
+                LOGGER.warning(
+                    f"Database Transaction Rolled Back : {exc_val}",
+                )
+            else:
+                LOGGER.exception(
+                    "Database Transaction Failed - Rolling Back",
+                )
             await self.session.rollback()
         await self.session.close()
 

--- a/apps/mirumoji/src/mirumoji/server/db/repos.py
+++ b/apps/mirumoji/src/mirumoji/server/db/repos.py
@@ -750,16 +750,37 @@ class JobRepository:
             RecordNotFoundError: If the job does not exist
             DatabaseError: If the lookup fails
         """
-        try:
-            job = await self.session.get(Job, job_id)
-        except Exception as e:
-            raise DatabaseError(f"Failed To Fetch Job : {e}") from e
+        job = await self.find(job_id)
         if job is None:
             raise RecordNotFoundError(
                 f"Job '{job_id}' Not Found",
                 details={"job_id": str(job_id)},
             )
-        return JobDTO.model_validate(job)
+        return job
+
+    async def find(self, job_id: uuid.UUID) -> JobDTO | None:
+        """
+        Fetches a job by id, or `None` when it does not exist
+
+        info: Non-Raising
+            Used where a missing job is an ordinary outcome rather than an
+            error, so the caller decides without paying for an exception
+            (see the idempotent delete route)
+
+        Args:
+            job_id (uuid.UUID): The job id
+
+        Returns:
+            The matching `JobDTO`, or `None` when no such job exists
+
+        Raises:
+            DatabaseError: If the lookup fails
+        """
+        try:
+            job = await self.session.get(Job, job_id)
+        except Exception as e:
+            raise DatabaseError(f"Failed To Fetch Job : {e}") from e
+        return JobDTO.model_validate(job) if job is not None else None
 
     async def list_for_profile(
         self,

--- a/apps/mirumoji/src/mirumoji/server/jobs.py
+++ b/apps/mirumoji/src/mirumoji/server/jobs.py
@@ -417,7 +417,10 @@ class JobQueueManager:
                     await uow.jobs.update(
                         job.id,
                         status="failed",
-                        error="Interrupted By A Server Restart",
+                        error=(
+                            "Interrupted By A Server Restart. Submit It "
+                            "Again To Retry"
+                        ),
                     )
                     orphaned += 1
                 elif job.parent_id is None:
@@ -431,7 +434,10 @@ class JobQueueManager:
                     await uow.jobs.update(
                         job.id,
                         status="failed",
-                        error="Interrupted By A Server Restart",
+                        error=(
+                            "Interrupted By A Server Restart. Submit It "
+                            "Again To Retry"
+                        ),
                     )
                     orphaned += 1
             await uow.commit()
@@ -440,6 +446,11 @@ class JobQueueManager:
                 await self.submit_job(job_id)
 
         if orphaned:
+            # Not re-queued on purpose: a job interrupted after its output
+            # landed but before its status was written would run its side
+            # effect twice, so the retry is left to the user. A host that is
+            # restarted by a spot reclaim can avoid this entirely by running
+            # on guaranteed capacity (`MIRUMOJI_HOST_NONPREEMPTIBLE`)
             LOGGER.warning(
                 f"Failed {orphaned} Orphaned Running "
                 f"Job(s) From A Previous Run"
@@ -475,7 +486,10 @@ class JobQueueManager:
                         await uow.jobs.update(
                             job.id,
                             status="failed",
-                            error="Interrupted By A Server Restart",
+                            error=(
+                                "Interrupted By A Server Restart. Submit It "
+                                "Again To Retry"
+                            ),
                         )
                         interrupted += 1
                 await uow.commit()

--- a/apps/mirumoji/src/mirumoji/server/media.py
+++ b/apps/mirumoji/src/mirumoji/server/media.py
@@ -27,14 +27,17 @@ info: Modal Paths
 """
 
 import asyncio
+import contextlib
 import logging
 import os
 import shutil
 import uuid
+from collections.abc import Iterator
 from pathlib import Path
 
 import aiofiles
 from fastapi import Request, UploadFile
+from starlette.requests import ClientDisconnect
 
 from ..exceptions import InvalidMediaPathError, StorageError, UploadError
 from ..paths import HOST_MEDIA_PATH
@@ -48,12 +51,11 @@ PROFILES_PATH: Path = BASE_PATH / "profiles"
 
 PARTIAL_SUFFIX: str = ".mirumoji-partial"
 """
-Reserved suffix of a media file that is still being written
+Reserved marker naming a media file that is still being written
 
-Writes land on a uniquely named `<name>.<token>.mirumoji-partial` sibling and
-are atomically renamed into place, so a reader never observes a partially
-written file, two concurrent writes never share a temporary, and the Modal-host
-volume syncer skips it (the reserved suffix never matches a real filename)
+Writes land on a uniquely named `<stem>.<token>.mirumoji-partial<ext>` sibling
+and are atomically renamed into place, so a reader never observes a partially
+written file and two concurrent writes never share a temporary
 """
 
 
@@ -62,16 +64,57 @@ def partial_path(path: Path) -> Path:
     Builds a unique temporary sibling path for an atomic write of `path`
 
     The random token keeps two concurrent writes to the same destination from
-    sharing a temporary file, and the reserved suffix keeps the Modal-host
+    sharing a temporary file, and the reserved marker keeps the Modal-host
     volume syncer from mirroring it
+
+    info: The Marker Sits Before The Extension
+        - `FFMPEG` picks its muxer from the output's extension and takes no
+          format flag here, so the temporary has to keep the real one
+
+        - Appending the marker would leave `ffmpeg` unable to infer a container
 
     Args:
         path (Path): The final destination path
 
     Returns:
-        A unique `<name>.<token>.mirumoji-partial` sibling of `path`
+        A unique `<stem>.<token>.mirumoji-partial<ext>` sibling of `path`
     """
-    return path.with_name(f"{path.name}.{uuid.uuid4().hex}{PARTIAL_SUFFIX}")
+    token = f".{uuid.uuid4().hex}{PARTIAL_SUFFIX}"
+    return path.with_name(f"{path.stem}{token}{path.suffix}")
+
+
+@contextlib.contextmanager
+def atomic_output(path: str | os.PathLike[str]) -> Iterator[Path]:
+    """
+    Yields a temporary sibling to write to, renamed into `path` on success
+
+    info: Producers That Write Their Own Output
+        The helpers in this module stream their own bytes, so they build the
+        temporary themselves. `FFMPEG` and `genanki` instead take a
+        destination path and write it over many seconds
+
+    Args:
+        path (str | os.PathLike[str]): The final destination path
+
+    Yields:
+        The temporary sibling to write to
+
+    Raises:
+        StorageError: If the finished output cannot be renamed into place
+    """
+    final = Path(path)
+    final.parent.mkdir(parents=True, exist_ok=True)
+    partial = partial_path(final)
+    try:
+        yield partial
+    except BaseException:
+        partial.unlink(missing_ok=True)
+        raise
+    try:
+        os.replace(partial, final)
+    except OSError as e:
+        partial.unlink(missing_ok=True)
+        raise StorageError(f"Failed To Finalise Output '{final}' : {e}") from e
 
 
 async def save_upload_file(
@@ -95,6 +138,7 @@ async def save_upload_file(
         `output_path`, if the file was written successfully
 
     Raises:
+        ClientDisconnect: If the client cancelled the upload
         UploadError: If the upload fails for any reason
     """
 
@@ -118,6 +162,14 @@ async def save_upload_file(
         await asyncio.to_thread(os.replace, partial, output)
 
         LOGGER.info(f"Saved {total_content} Bytes To {output}")
+
+    except ClientDisconnect:
+        # The client cancelled the upload, which is an ordinary outcome rather
+        # than a failure. The temporary is dropped and nothing is renamed into
+        # place, so the caller never records a half-uploaded file
+        partial.unlink(missing_ok=True)
+        LOGGER.info(f"Upload To {output} Cancelled By The Client")
+        raise
 
     except Exception as e:
         # Clean Up Partially Written File

--- a/apps/mirumoji/src/mirumoji/server/processing/processor.py
+++ b/apps/mirumoji/src/mirumoji/server/processing/processor.py
@@ -325,13 +325,17 @@ class Processor:
             "use_gpu": await asyncio.to_thread(nvenc_available, ffmpeg),
             **(to_mp4_kwargs or {}),
         }
-        await asyncio.to_thread(
-            audio.to_mp4,
-            ffmpeg_path=ffmpeg,
-            input_path=str(input_path),
-            output_path=str(out),
-            **kwargs,
-        )
+        # The encode lands on a temporary sibling, so a host whose media tree
+        # is mirrored to a volume (see `launcher.modal.app`) copies the
+        # finished MP4 once instead of re-copying it as ffmpeg grows it
+        with media.atomic_output(out) as out_partial:
+            await asyncio.to_thread(
+                audio.to_mp4,
+                ffmpeg_path=ffmpeg,
+                input_path=str(input_path),
+                output_path=str(out_partial),
+                **kwargs,
+            )
         return out
 
     # --- Modal Batch Helpers ---

--- a/apps/mirumoji/src/mirumoji/server/routers/jobs.py
+++ b/apps/mirumoji/src/mirumoji/server/routers/jobs.py
@@ -102,19 +102,24 @@ async def submit_job(
             detail=f"Invalid File Id '{req.file_id}'",
         ) from e
 
+    # The ownership check reads the already-fetched record, so it is raised
+    # outside the transaction. Raising it inside would make the `UnitOfWork`
+    # log an ordinary 404 as a failed transaction
     async with UnitOfWork() as uow:
         file_rec = await uow.files.get(file_uuid)
-        if file_rec.profile_id != profile_id:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail="File Not Found",
+        owned = file_rec.profile_id == profile_id
+        if owned:
+            job = await uow.jobs.add(
+                profile_id=profile_id,
+                type=req.type,
+                params=req.to_params(),
             )
-        job = await uow.jobs.add(
-            profile_id=profile_id,
-            type=req.type,
-            params=req.to_params(),
+            await uow.commit()
+    if not owned:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="File Not Found",
         )
-        await uow.commit()
 
     await manager.submit_job(job.id)
     LOGGER.info(
@@ -356,6 +361,16 @@ async def delete_job(
     job whose handler has not returned yet) is refused, so the worker is never
     left holding a deleted row
 
+    info: Idempotent
+        - Deleting a job that is already gone succeeds, matching `DELETE`
+          semantics and `JobRepository.delete`, which is a no-op on a missing
+          row
+
+        - Deleting a file removes the jobs that reference it, so a client
+          holding a list from before that delete would otherwise get a `404`
+          it can never clear. The ownership and in-flight checks do not apply
+          to a row that no longer exists
+
     Args:
         job_id (uuid.UUID): The job id
         profile_id (str): Validated profile id
@@ -364,24 +379,33 @@ async def delete_job(
     Raises:
         HTTPException: If the job isn't owned by the profile, or is still
             active or in flight
-        RecordNotFoundError: If the job does not exist
         DatabaseError: If the deletion fails
     """
+    # The ownership and in-flight checks read the already-fetched record, so
+    # they are raised outside the transaction. Raising them inside would make
+    # the `UnitOfWork` log an ordinary client condition as a failed transaction
+    conflict: HTTPException | None = None
     async with UnitOfWork() as uow:
-        job = await uow.jobs.get(job_id)
+        job = await uow.jobs.find(job_id)
+        if job is None:
+            LOGGER.info(f"Job '{job_id}' Already Deleted, Nothing To Do")
+            return
         if job.profile_id != profile_id:
-            raise HTTPException(
+            conflict = HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="Job Not Found",
             )
-        if (
+        elif (
             job.status in ("queued", "running")
             or job_id == manager.running_job_id
         ):
-            raise HTTPException(
+            conflict = HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="The Job Is Still Finishing, Try Again In A Moment",
             )
-        await uow.jobs.delete(job_id)
-        await uow.commit()
+        else:
+            await uow.jobs.delete(job_id)
+            await uow.commit()
+    if conflict is not None:
+        raise conflict
     LOGGER.info(f"Job '{job_id}' Deleted For Profile '{profile_id}'")

--- a/apps/mirumoji/src/mirumoji/server/routers/profile.py
+++ b/apps/mirumoji/src/mirumoji/server/routers/profile.py
@@ -261,14 +261,17 @@ async def save_clip(
         await media.save_upload_object(clip_file, src)
 
         # Convert to WebM for Anki compatibility. VP9 has no NVENC encoder, so
-        # this is always a CPU encode (the clip is short)
+        # this is always a CPU encode (the clip is short). The encode lands on
+        # a temporary sibling so the Modal-host volume syncer mirrors the
+        # finished clip once instead of re-copying it as ffmpeg writes it
         ffmpeg = audio.get_ffmpeg_path()["ffmpeg"]
-        await asyncio.to_thread(
-            audio.to_webm,
-            ffmpeg_path=ffmpeg,
-            input_path=str(src),
-            output_path=str(webm_loc),
-        )
+        with media.atomic_output(webm_loc) as webm_partial:
+            await asyncio.to_thread(
+                audio.to_webm,
+                ffmpeg_path=ffmpeg,
+                input_path=str(src),
+                output_path=str(webm_partial),
+            )
 
         async with UnitOfWork() as uow:
             file_rec = await uow.files.add(
@@ -524,6 +527,10 @@ async def delete_file(
         StorageError: If deleting the file fails
         DatabaseError: If the deletion fails
     """
+    # The in-flight check reads the already-fetched job ids, so it is raised
+    # outside the transaction. Raising it inside would make the `UnitOfWork`
+    # log an ordinary 409 as a failed transaction
+    in_flight = False
     async with _file_delete_lock(), UnitOfWork() as uow:
         file = await uow.files.get(file_id)
         if file.profile_id != profile_id:
@@ -532,15 +539,17 @@ async def delete_file(
                 details={"file_id": str(file_id)},
             )
         dependent = await uow.jobs.find_referencing_file(profile_id, file_id)
-        if manager.running_job_id in dependent:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="A Running Job Uses This File, Cancel It First",
-            )
-        for job_id in dependent:
-            await uow.jobs.delete(job_id)
-        await uow.files.delete(file_id)
-        await uow.commit()
+        in_flight = manager.running_job_id in dependent
+        if not in_flight:
+            for job_id in dependent:
+                await uow.jobs.delete(job_id)
+            await uow.files.delete(file_id)
+            await uow.commit()
+    if in_flight:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A Running Job Uses This File, Cancel It First",
+        )
     await media.delete_file(file.path)
     LOGGER.info(f"Deleted File '{file_id}' For Profile '{profile_id}'")
     return FileDeleteResponse(
@@ -774,7 +783,10 @@ async def export_anki_deck(
 
     anki_dir = media.get_profile_dir(profile_id, "anki")
     out_loc = anki_dir / f"{uuid.uuid4().hex}_saved_deck.apkg"
-    await asyncio.to_thread(anki.export_deck, cards, str(out_loc))
+    # Written to a temporary sibling first, so the Modal-host volume syncer
+    # never mirrors a half-packaged deck
+    with media.atomic_output(out_loc) as out_partial:
+        await asyncio.to_thread(anki.export_deck, cards, str(out_partial))
 
     rel_out = media.get_relative_path(out_loc)
     LOGGER.info(

--- a/docs/site/docs_md/cli.md
+++ b/docs/site/docs_md/cli.md
@@ -298,8 +298,11 @@ mirumoji modal logs [OPTIONS]
 
 | Option | Default | Description |
 | --- | --- | --- |
-| `-n`, `--tail N` | `100` | How Many Recent Log Entries To Fetch |
+| `-n`, `-t`, `--tail N` | `100` | How Many Recent Log Entries To Fetch, From `1` To `20000` *(Ignored With `--follow`)* |
 | `-f`, `--follow` | off | Live-Stream The Logs Until Interrupted *(Ctrl-C)* |
+
+!!! note "Tail Bound"
+    `20000` Is The Largest `--tail` `Modal` Accepts. A Follow Always Starts From The Newest Entries, So `--tail` Only Applies To A One-Shot Fetch
 
 ### `modal down`
 

--- a/docs/site/docs_md/project/changelog.md
+++ b/docs/site/docs_md/project/changelog.md
@@ -19,6 +19,92 @@ starting from **`v3.0.0`**
 
 ---
 
+## [`3.7.0`](https://github.com/svdC1/mirumoji/releases/tag/v3.7.0) - 2026-07-20
+
+This release stops a local video being uploaded once per player action,
+makes the interface report what actually happened instead of assuming success,
+and fixes two `GUI` `Modal` actions that opened a second window and hung forever.
+It also adds upload cancellation, double-tap seeking, a `Modal` log source in
+the `GUI`, and quiets a large amount of misleading `ERROR` noise in the host logs.
+It has no breaking changes
+
+### Added
+
+- `Frontend` &rarr; An in-flight upload can be cancelled from the task tray, which
+  stops the transfer and drops the row rather than leaving it to finish
+
+- `Frontend` &rarr; Double-tapping the left or right side of the player skips 5
+  seconds, matching the arrow keys
+
+- `Launcher` &rarr; The `GUI` Logs panel reads the `Modal`-hosted app's logs as
+  well as the local `Docker Compose` stack, chosen with a new Source control,
+  with the same tail and follow controls
+
+### Fixed
+
+- `Frontend` &rarr; Running two player actions on the same device video uploaded
+  the whole file twice. Clicking `Generate SRT` and `To MP4` on one video sent it
+  in full on each action and left two profile files sharing a name. An action
+  started while an upload is still running now joins that upload instead of
+  beginning its own
+
+- `Frontend` &rarr; A player action on a file that had since been deleted reported
+  success while the server rejected it, and no task ever appeared. Actions now
+  wait for the result and report the real outcome, naming a deleted file rather
+  than failing silently
+
+- `Frontend` &rarr; A profile video deleted while it was loaded showed the
+  `Convert To Play` prompt, which could never succeed. A deleted file is now told
+  apart from a container the browser cannot decode, and clears the player
+
+- `Frontend` &rarr; Deleting a file left the jobs it removed on the tasks
+  dashboard, where deleting them failed with a not-found error that could not be
+  cleared. Those jobs are dropped as the file is deleted, and any task that is
+  already gone server-side clears instead of erroring. Transcripts and clips are
+  refreshed the same way
+
+- `Frontend` &rarr; On `iOS` a recording's audio slider never moved and its length
+  showed as `0:00`, because a browser recording carries no duration until it has
+  been read in full. The duration is now picked up when it becomes known
+
+- `Frontend` &rarr; On `iOS` the file dialog stopped responding after a few
+  uploads. Picking the same file twice raised no event, and each preview held its
+  audio in memory for the rest of the session, so repeated picks exhausted the
+  browser. File inputs now reset between picks and previews are released once
+  nothing shows them
+
+- `Launcher` &rarr; `Down` and `Download Data` in the `GUI`'s `Modal Host` panel
+  opened a second application window and hung indefinitely. The packaged app
+  embeds `Python`, so the `modal` CLI could not be run the way those two actions
+  ran it. `Download Data` now streams the volume directly and `Down` stops the app
+  in-process, so neither spawns anything
+
+- `Launcher` &rarr; The `Modal Host` panel's mode pills kept whatever was true
+  when the panel first opened, so a change made in `Settings` was not reflected on
+  returning to it. They are re-read on every visit, as the `Dashboard` already did
+
+- `CLI` &rarr; `mirumoji modal logs --tail` accepted counts the `modal` CLI
+  rejects, surfacing its raw usage text. It is bounded to the accepted range, also
+  takes `-t`, and states that it does not apply with `--follow`
+
+- `Server` &rarr; Video conversions, saved clips and `Anki` exports were mirrored
+  to the `Modal` volume repeatedly while they were still being written, re-copying
+  the same output several times over. Each is now written aside and moved into
+  place when finished, so it is copied once
+
+- `Server` &rarr; Ordinary outcomes were logged as failures. A stale reference
+  from the interface produced a database `ERROR` and a full traceback on every
+  attempt, burying real problems. Only genuine failures are logged that way now
+
+- `Server` &rarr; Deleting a task that was already gone failed instead of
+  succeeding, which left the interface unable to clear it. Deleting a task that no
+  longer exists now succeeds
+
+- `Server` &rarr; A cancelled upload was recorded as a server failure rather than
+  as the deliberate action it is
+
+---
+
 ## [`3.6.0`](https://github.com/svdC1/mirumoji/releases/tag/v3.6.0) - 2026-07-18
 
 This release hardens the `Modal`-hosted deploy and adds new host compute modes.

--- a/docs/site/docs_md/setup/gui.md
+++ b/docs/site/docs_md/setup/gui.md
@@ -84,7 +84,7 @@ The `Desktop Launcher` Has 5 Panels
 | **Dashboard** | Start / Stop / Build Images / Watch Status |
 | **Environment** | Run Dependency Checks *(Same as `mirumoji doctor`)* |
 | **Settings** | Choose The Transcription Backend / Image Source / Image Version, Set LLM / Modal API Keys + Advanced Overrides, Delete All Local Data |
-| **Logs** | Stream + Filter The Docker Compose Application's Logs |
+| **Logs** | Stream + Filter The Docker Compose Application's Logs, Or Read The `Modal`-Hosted App's |
 | **Modal Host** | Deploy, Inspect, Tear Down, And Back Up The Full App On Your `Modal` Account *(mirrors the [`modal`](../cli.md#modal-host-commands) CLI commands)* |
 
 ### Typical First Run
@@ -124,3 +124,18 @@ The config pills show what a deploy would use *(CPU, memory, requests, image ver
 
 !!! tip "Full Walkthrough"
     See the [`Modal Host Setup`](modal-host.md) guide for the complete flow, including the GPU and non-preemptible host options
+
+## Reading Logs
+
+The `Logs` panel streams the local `Docker Compose` application, and can also read the `Modal`-hosted app
+
+- **Source** &rarr; Choose Between `Docker` And `Modal`
+
+- **Service** &rarr; Narrow The Stream To One Container. `Docker` Only, So It Is Disabled Under `Modal`
+
+- **Tail Lines** &rarr; How Much Recent History To Fetch
+
+- **Follow** &rarr; Keep Streaming Until You Press `Stop`
+
+!!! note "Modal Logs"
+    The `Modal` source needs your `Modal` credentials set and the host deployed. It mirrors [`mirumoji modal logs`](../cli.md#modal-logs), so `Tail Lines` is capped at `20000` and is ignored while `Follow` is on

--- a/docs/site/docs_md/setup/modal-host.md
+++ b/docs/site/docs_md/setup/modal-host.md
@@ -42,6 +42,8 @@ By default a deploy creates two `Modal` apps and one volume in your workspace
 
     - **Non-Preemptible CPU Host** &rarr; Set `MIRUMOJI_HOST_NONPREEMPTIBLE=1` to run the `CPU-Only` host on guaranteed capacity *(a 3x price)* so a spot reclaim never restarts it mid-job. `Modal` does not allow this on a GPU host, so the two options can't be combined
 
+    - A restart matters because a job that was running at the time is marked failed rather than re-queued. Re-running it automatically could duplicate an output that had already been written but not yet recorded, so the retry is left to you. Long batches are the case that benefits most from guaranteed capacity
+
 ## Prerequisites
 
 You'll need a [`Modal`](https://modal.com) account with your `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` configured. This is the same token pair that the `modal` backend uses, so if you have already set that up you are ready. If not, follow [`Get Your API Token Pair`](../guides/gpu.md#get-your-api-token-pair)
@@ -100,9 +102,11 @@ Once you log in, the whole app loads and works exactly like a local install, wit
 Unlike a local install *(which keeps your data in local Docker volumes)*, the hosted app stores your media and database in the `mirumoji-data` [`Modal Volume`](https://modal.com/docs/guide/volumes), created automatically on the first deploy
 
 ???+ question "How It Stays Fast And Durable"
-    - The host does not read and write directly on the volume, whose network layer is slow for the many small, random reads that video playback and the database make. It operates on the container's local disk and mirrors every change to the volume in the background
+    - The host does not read and write directly on the volume, whose network layer is slow for the many small, random reads that video playback and the database make. It operates on the container's local disk and mirrors your media and database to the volume in the background. Scratch a job re-creates each run is skipped, and a file still being written is only mirrored once it is complete
 
     - `Modal` commits the volume as the app runs and on shutdown, and the host restores it into the container on every start, so your data survives a redeploy, a stop, or a spot preemption
+
+    - This covers your stored data, not work in progress. A job that was running when the container restarted is marked failed and has to be submitted again *(see [`How It Works`](#how-it-works) for the non-preemptible option that avoids the restart entirely)*
 
 === "Back It Up"
     Download everything in the volume to a local folder at any time

--- a/scripts/generate_demo_data.py
+++ b/scripts/generate_demo_data.py
@@ -466,9 +466,7 @@ class Driver:
         # its audio section (apiKanjiAudio falls back to no clips on a 404)
         if not self.kanji_audio:
             return
-        audio = self.get(
-            "dict/kanji/audio?" + urlencode({"literal": literal})
-        )
+        audio = self.get("dict/kanji/audio?" + urlencode({"literal": literal}))
         clips = audio.get("clips", []) if isinstance(audio, dict) else []
         for clip in clips:
             resp = self.client.get(


### PR DESCRIPTION
# 3.7.0 Summary

Fixes several bugs found in 3.6.0 and adds 2 new features.  No breaking changes

**Problems** &rarr; A local video was uploaded once
per player action, so two clicks sent 460 MB twice. The interface reported success for work the
server had rejected, two GUI Modal actions opened a second window and hung
forever in the GUI, and a large amount of ordinary client behaviour was being logged as
server crashes.


## Producer Writes And Log Classification (1506309)

### Problem

Three separate issues, all server-side

- `FFMPEG` and `genanki` wrote directly to their final path inside the media
tree.The Modal-host volume syncer watches that tree, so every growth event
re-copied the entire output

- `UnitOfWork.__aexit__` called `LOGGER.exception` for every exception crossing
it, so an expected 404 produced an ERROR and a full Rich traceback

- `DELETE /api/jobs/{id}` was not idempotent. `JobRepository.delete` already was,
documented as such, but the raising `get` one layer up short-circuited it. The
log shows the same id 404ing twice, six seconds apart, because the UI had no
way to clear the row

### Fix

- A `media.atomic_output()` context manager, applied at the clip WebM, the
local-backend MP4, and the anki export. Each writes to a reserved-marker
sibling the syncer skips and is renamed into place, so it reaches the volume
once and an interrupted encode leaves nothing behind

- This forced a change to the marker's position. `partial_path` used to append
it (`clip.webm` → `clip.webm.<uuid>.mirumoji-partial`), but `to_mp4` and
`to_webm` pass no `-f` flag, so ffmpeg picks its muxer from the extension and
that name would have failed every conversion. The marker now sits before the
extension (`clip.<uuid>.mirumoji-partial.webm`) and `_is_partial` matches it
anywhere in the name rather than only at the end

- `__aexit__` branches on `MirumojiServerError.http_status`: below 500 logs a
warning with no `exc_info`, 500 and above keeps the traceback. The rollback is
unconditional in both branches. `RecordNotFoundError` is no longer a
`DatabaseError`, and four ownership and in-flight checks that only read an
already-fetched record moved outside their transactions rather than teaching
the DB layer about FastAPI

- `delete_job` uses a new non-raising `JobRepository.find` and returns 204 when
the row is already gone. A cancelled upload now raises `ClientDisconnect`
instead of being wrapped as a server failure, and the syncer logs its database
copies, previously its only silent operation


## GUI Modal Actions (f4055ef)

### Problem

- `Down` and `Download Data` opened a second application window and hung
indefinitely. `flet build` embeds Python in the app binary, so `sys.executable`
is `Mirumoji.exe`. `Mirumoji.exe -m modal app stop …` ignores its arguments and
launches another copy of the GUI, which the parent then blocks on. These were
the only two actions that shelled out, which is exactly why they were the only
two that hung. Deploy and Status use the SDK and always worked

- The `Modal Host` panel built once and cached, and
`show()` only re-synced index 0, so the mode pills kept whatever was true when
the panel first opened

-  `modal logs --tail` was unbounded, while the modal CLI rejects anything above 20000 with raw usage text

### Fix


- `Download Data` drops the subprocess entirely and walks the volume through the
SDK. `Down` calls modal's own command callback in-process, behind a narrow
wrapper with a subprocess fallback so a modal release that moves it degrades
rather than breaking the GUI. Remaining spawns resolve a real interpreter and
pass `stdin=DEVNULL`, which all three modal call sites had been missing

- Panel refresh callbacks moved to a registry keyed by navigation index, so the
pills re-read on every visit as the Dashboard already did

- `--tail` is bounded to
1..20000, takes `-t` alongside `-n`, and documents that it does not apply with 
`--follow`.


## Frontend Correctness (0879963)

### Problem

- The duplicate upload. `TaskContext` cached the *resolved* file id and only
wrote it after the upload resolved, so a second action fired during the upload
window read nothing and started its own transfer, Same name, same byte count, two profile files.
Clicking `Generate SRT` and `To MP4` on one video sent 460 MB twice

- The player toasted success synchronously and discarded the promise with `void`,
so a submit against a deleted file reported success while the server answered
404 and no task appeared. The cached-id branch also sat outside its `try`, so
that path produced an unhandled rejection with no tray row at all

- Deleting a file left its cascaded jobs on screen. The Files and Tasks tabs
never mount together, so `mutate("jobs/history")` had no subscriber and did
nothing, and `TaskContext` never evicted terminal jobs so completed ones were
resurrected into the merged list

- On iOS the audio slider never moved and the length read `0:00`, because
MediaRecorder WebM carries no duration until fully read, so `a.duration` is
`Infinity`, which was stored as `0` and pinned the range input at `max={0}`.
The file dialog also stopped responding after a few uploads

### Fix

- The cache holds the in-flight *promise*, registered synchronously before the
first `await`, so a second action joins the first upload. It is keyed by name,
size and modified time rather than `File` identity, because re-picking the same
file yields a new `File` object and the old `Map<File, …>` strongly retained
every uploaded file for the session, Button guards are per-action rather than global,
since a global flag would have blocked the second action instead of letting it share
the upload

- Submissions are awaited and toasts gated on the result. A deleted profile video
is told apart from an undecodable container via a `HEAD` probe, so it clears
the player instead of offering a conversion that cannot succeed.

- Uploads can be cancelled. `settleUpload` had no `onabort`, so calling `abort()`
would have left the promise pending forever.

- The jobs cache is written through directly rather than revalidated, terminal
jobs are evicted, and a 404 from a job delete counts as success so a stale row
always clears. Transcripts and clips are revalidated too, which cascade
server-side and never were

- `durationchange` is observed alongside a `readyState` catch-up on mount and a
reset per source. File inputs clear their value on every pick and mount outside
the popover that could unmount them mid-pick, and preview object URLs are
revoked once no message still renders them

- Double-tapping either side of the
player seeks 5s, reusing the existing arrow-key logic behind a 250 ms
single-tap delay


## Docs (b06a0d4)

A `Reading Logs` section for the GUI guide, the `--tail` bound and `-t` alias
in the CLI reference, and an update about preemption. The host
guide promised data survives a spot reclaim without saying that a job running
at the time does not. It now states that such a job is marked failed rather
than re-queued, since re-running one whose output had already landed would
duplicate it, which is the reason to reach for `MIRUMOJI_HOST_NONPREEMPTIBLE`.
The durability note also stops claiming every change is mirrored, since scratch
is skipped and an in-progress file is only mirrored once complete


## Deliberate Non-Change

Interrupted jobs are still failed rather than re-queued on restart. Re-running
a job that finished its work but crashed before its status was written would
duplicate the output, so the retry is left to the user and `MIRUMOJI_HOST_NONPREEMPTIBLE`
is documented as the way to avoid the restart