### PR TITLE
V371

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.7.0",
+    "version": "3.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mirumoji-ui",
-            "version": "3.7.0",
+            "version": "3.7.1",
             "dependencies": {
                 "@fontsource/hanken-grotesk": "^5.2.8",
                 "@fontsource/newsreader": "^5.2.10",
@@ -135,7 +135,6 @@
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -1817,7 +1816,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -1841,7 +1839,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1853,7 +1850,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "@emnapi/wasi-threads": "1.2.1",
                 "tslib": "^2.4.0"
@@ -1866,7 +1862,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -3335,7 +3330,6 @@
             "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -3351,7 +3345,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
             "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/prop-types": "*",
                 "csstype": "^3.2.2"
@@ -3422,7 +3415,6 @@
             "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.61.0",
                 "@typescript-eslint/types": "8.61.0",
@@ -3772,7 +3764,6 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4277,7 +4268,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -4706,8 +4696,7 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/data-urls": {
             "version": "5.0.0",
@@ -5261,7 +5250,6 @@
             "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -7037,7 +7025,6 @@
             "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "jiti": "bin/jiti.js"
             }
@@ -7077,7 +7064,6 @@
             "integrity": "sha512-L88oL7D/8ufIES+Zjz7v0aes+oBMh2Xnh3ygWvL0OaICOomKEPKuPnIfBJekiXr+BHbbMjrWn/xqrDQuxFTeyA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@asamuzakjp/dom-selector": "^2.0.1",
                 "cssstyle": "^4.0.1",
@@ -9177,7 +9163,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.12",
                 "picocolors": "^1.1.1",
@@ -9505,7 +9490,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
             "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0"
             },
@@ -9518,7 +9502,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
             "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "loose-envify": "^1.1.0",
                 "scheduler": "^0.23.2"
@@ -9937,7 +9920,6 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.0.tgz",
             "integrity": "sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.9"
             },
@@ -10870,7 +10852,6 @@
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -11086,7 +11067,6 @@
             "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "dependencies": {
                 "@gerrit0/mini-shiki": "^3.23.0",
                 "lunr": "^2.3.9",
@@ -11167,7 +11147,6 @@
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -11476,7 +11455,6 @@
             "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "lightningcss": "^1.32.0",
                 "picomatch": "^4.0.4",
@@ -11982,7 +11960,6 @@
             "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -12203,7 +12180,6 @@
             "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "yaml": "bin.mjs"
             },

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.7.0",
+    "version": "3.7.1",
     "private": true,
     "type": "module",
     "engines": {

--- a/apps/frontend/src/features/profile/components/ClipsPanel.tsx
+++ b/apps/frontend/src/features/profile/components/ClipsPanel.tsx
@@ -36,17 +36,24 @@ export function ClipsPanel() {
     if (!profileId) return <NoProfile what="view your saved clips" />;
     if (isLoading && !data) return <PanelLoading />;
 
+    // The delete is optimistic: the clip leaves the cached list before the
+    // request so the panel responds on click even on a high-latency host, and
+    // a revalidation follows to reconcile (restoring the clip if the delete
+    // failed).
     const onDelete = async (id: string) => {
         setDeleting(id);
         const tId = toast.loading("Deleting Clip ...");
+        void mutate(key, (current?: Clip[]) => current?.filter((c) => c.id !== id), {
+            revalidate: false,
+        });
         try {
             await deleteClip(id);
             toast.success("Clip Deleted", { id: tId });
             if (selected?.id === id) setSelected(null);
-            mutate(key);
         } catch (e) {
             toastApiError(e, tId);
         } finally {
+            void mutate(key);
             setDeleting(null);
         }
     };

--- a/apps/frontend/src/features/profile/components/FilesPanel.tsx
+++ b/apps/frontend/src/features/profile/components/FilesPanel.tsx
@@ -195,8 +195,23 @@ export function FilesPanel() {
         void mutate("profiles/clips");
     };
 
+    // Deletes are optimistic: the rows leave the cached list before the
+    // request so the panel responds on click even on a high-latency host. A
+    // failed delete is restored by the follow-up revalidation of the files
+    // key (reconcileAfterDelete on the shared path, the explicit mutate in
+    // the single-delete catch), which re-adds whatever the server still has.
+    const dropFromCache = (ids: string[]) => {
+        const dropping = new Set(ids);
+        void mutate(
+            SWR_KEY,
+            (current?: ProfileFile[]) => current?.filter((f) => !dropping.has(f.id)),
+            { revalidate: false }
+        );
+    };
+
     const onDelete = async (id: string) => {
         setDeleting(id);
+        dropFromCache([id]);
         try {
             const res = await deleteFile(id);
             toast.success("File Deleted");
@@ -208,6 +223,7 @@ export function FilesPanel() {
             reconcileAfterDelete([id], res.deleted_job_ids);
         } catch (e) {
             toastApiError(e);
+            void mutate(SWR_KEY);
         } finally {
             setDeleting(null);
         }
@@ -216,6 +232,7 @@ export function FilesPanel() {
     const deleteSelected = async () => {
         const ids = [...selected];
         if (ids.length === 0) return;
+        dropFromCache(ids);
         const results = await Promise.allSettled(ids.map((id) => deleteFile(id)));
         const ok = results.filter((r) => r.status === "fulfilled").length;
         const deletedFileIds: string[] = [];

--- a/apps/frontend/src/features/profile/components/TranscriptsPanel.tsx
+++ b/apps/frontend/src/features/profile/components/TranscriptsPanel.tsx
@@ -50,15 +50,22 @@ export function TranscriptsPanel() {
         );
     }
 
+    // The delete is optimistic: the card leaves the cached list before the
+    // request so the panel responds on click even on a high-latency host, and
+    // a revalidation follows to reconcile (restoring the card if the delete
+    // failed).
     const onDelete = async (id: string) => {
         setDeleting(id);
+        void mutate(key, (current?: ProfileTranscript[]) => current?.filter((t) => t.id !== id), {
+            revalidate: false,
+        });
         try {
             await deleteTranscript(id);
             toast.success("Transcript Deleted");
-            mutate(key);
         } catch (e) {
             toastApiError(e);
         } finally {
+            void mutate(key);
             setDeleting(null);
         }
     };

--- a/apps/mirumoji/pyproject.toml
+++ b/apps/mirumoji/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mirumoji"
-version = "3.7.0"
+version = "3.7.1"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "Self-Hostable Japanese Language Immersion Tool"

--- a/apps/mirumoji/src/mirumoji/__init__.py
+++ b/apps/mirumoji/src/mirumoji/__init__.py
@@ -7,4 +7,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("mirumoji")
 except PackageNotFoundError:
-    __version__ = "3.7.0"
+    __version__ = "3.7.1"

--- a/apps/mirumoji/src/mirumoji/launcher/cli/commands.py
+++ b/apps/mirumoji/src/mirumoji/launcher/cli/commands.py
@@ -1469,12 +1469,8 @@ def modal_logs(
             # command uses, so the GUI can follow and cancel it the same way
             handle = process.StreamHandle()
             stream_logs(
-                gen=process.stream(
-                    modal_lifecycle.app_logs_command(
-                        HOST_APP_NAME, follow=True, tail=tail
-                    ),
-                    check=False,
-                    handle=handle,
+                gen=modal_lifecycle.follow_app_logs(
+                    HOST_APP_NAME, tail=tail, handle=handle
                 ),
                 identifier="Modal",
                 handle=handle,

--- a/apps/mirumoji/src/mirumoji/launcher/gui/panels/logs.py
+++ b/apps/mirumoji/src/mirumoji/launcher/gui/panels/logs.py
@@ -10,7 +10,7 @@ from collections.abc import Generator
 import flet as ft
 
 from ....paths import HOST_CONFIG_FILE
-from ...core import envfile, lifecycle, process
+from ...core import envfile, lifecycle
 from ...core.compose import RESOLVED_COMPOSE_PATH
 from ...core.constants import BACKEND_SERVICE, FRONTEND_SERVICE
 from ...core.process import StreamHandle
@@ -62,19 +62,19 @@ def _modal_logs(
     env = envfile.resolve_managed_config(HOST_CONFIG_FILE)
     entries = min(tail or 100, MODAL_LOGS_MAX_TAIL)
     with modal_lifecycle.modal_credentials(env):
-        # Both modes go through the same stream. A fetch exits on its own once
-        # it has printed its entries, so it needs no separate path, and the
-        # lines land in the terminal as they arrive rather than in one block
-        #
-        # `check=False` because cancelling kills the process, which then exits
-        # non-zero through no fault of its own
-        yield from process.stream(
-            modal_lifecycle.app_logs_command(
-                HOST_APP_NAME, follow=follow, tail=entries
-            ),
-            check=False,
-            handle=handle,
-        )
+        # Both paths work in-process when the packaged GUI has no interpreter
+        # to spawn a `modal` CLI with (see `follow_app_logs` for the follow
+        # fallback), so Modal logs stay readable in the frozen bundle
+        if follow:
+            yield from modal_lifecycle.follow_app_logs(
+                HOST_APP_NAME, tail=entries, handle=handle
+            )
+            return
+        output = modal_lifecycle.fetch_app_logs(HOST_APP_NAME, entries)
+        if not output.strip():
+            yield "No Log Entries"
+            return
+        yield from output.rstrip("\n").splitlines()
 
 
 def build(page: ft.Page, state: AppState) -> ft.Control:

--- a/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
@@ -12,11 +12,14 @@ operations defined below
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import subprocess
-from collections.abc import Iterator
+import time
+from collections.abc import Generator, Iterator
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 
 from ...exceptions import ModalError
@@ -29,6 +32,7 @@ from ...modal import (
     modal_cli_argv,
     stop,
 )
+from ..core.process import StreamHandle, stream
 
 __all__ = [
     "VERSION_KEY",
@@ -39,6 +43,7 @@ __all__ = [
     "download_volume",
     "ensure_volume",
     "fetch_app_logs",
+    "follow_app_logs",
     "modal_credentials",
     "stop",
     "volume_exists",
@@ -346,6 +351,109 @@ def download_volume(name: str, destination: Path) -> None:
     )
 
 
+_FOLLOW_POLL_SECONDS = 2.0
+"""
+How long the in-process follow fallback waits between log polls
+"""
+
+_FOLLOW_POLL_STEP = 0.2
+"""
+How often the poll wait checks its `StreamHandle` for a stop request, so the
+Stop button stays responsive while the fallback sleeps between polls
+"""
+
+_FOLLOW_POLL_LIMIT = 1000
+"""
+How many entries each follow poll requests, bounding a burst between polls
+"""
+
+
+def _tail_logs_in_process(
+    name: str,
+    tail: int,
+    since: datetime | None = None,
+) -> list[tuple[float, str]]:
+    """
+    Fetches recent log entries of a deployed Modal app through the SDK
+
+    question: Why Not A Subprocess
+        - The Modal SDK exposes no public log reader, and the packaged desktop
+          GUI has no interpreter to shell out with, so the CLI's underlying
+          fetch helper is driven directly
+
+        - The internals are imported inside the function so a modal release
+          that moves or reshapes them surfaces as `ImportError` or
+          `AttributeError`, which the caller turns into a CLI fallback rather
+          than a hard failure (the `_stop_in_process` contract)
+
+    info: Cursor Fetches
+        `since` is an inclusive hard floor in modal's fetch, so a follow
+        caller can poll with the newest timestamp it has seen and drop the
+        entries it already yielded
+
+    Args:
+        name (str): The deployed app name
+        tail (int): How many recent entries to fetch
+        since (datetime | None): Only return entries at or after this time
+
+    Returns:
+        The fetched entries as `(timestamp, text)` pairs
+
+    Raises:
+        ModalError: If the app is not deployed
+        ImportError: If modal no longer ships the internals driven here
+        AttributeError: If modal reshaped those internals
+    """
+    import modal
+    from modal._logs import tail_logs
+    from modal.client import _Client
+    from modal.exception import NotFoundError
+
+    try:
+        app_id = modal.App.lookup(name, create_if_missing=False).app_id
+    except NotFoundError as e:
+        raise ModalError(f"The Modal App '{name}' Is Not Deployed") from e
+    if app_id is None:
+        raise ModalError(f"The Modal App '{name}' Is Not Deployed")
+
+    async def _collect() -> list[tuple[float, str]]:
+        client = await _Client.from_env()
+        entries: list[tuple[float, str]] = []
+        async for batch in tail_logs(client, app_id, tail, since=since):
+            for item in batch.items:
+                entries.append((item.timestamp, item.data))
+        return entries
+
+    return asyncio.run(_collect())
+
+
+def _format_log_lines(entries: list[tuple[float, str]]) -> list[str]:
+    """
+    Renders fetched `(timestamp, text)` log entries as timestamped lines
+
+    An entry's text can span multiple lines, so each is split and every line
+    carries the entry's `ISO-8601` `UTC` timestamp. Empty entries are skipped.
+    The rendering is close to, though not byte-identical with, the
+    `modal app logs --timestamps` output the CLI path produces
+
+    Args:
+        entries (list[tuple[float, str]]): The fetched log entries
+
+    Returns:
+        The timestamped log lines
+    """
+    lines: list[str] = []
+    for timestamp, data in entries:
+        if not data:
+            continue
+        prefix = datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        for line in data.splitlines():
+            lines.append(f"{prefix} {line}")
+    return lines
+
+
 def app_logs_command(name: str, *, follow: bool, tail: int) -> list[str]:
     """
     Builds the `modal app logs` argv for fetching or following an app's logs
@@ -381,15 +489,13 @@ def fetch_app_logs(name: str, tail: int) -> str:
     """
     Fetches the most recent log entries of a deployed Modal app
 
-    info: CLI-Backed
-        - The `Modal` SDK exposes no log reader, so this shells out to
-          `modal app logs`, which resolves a deployed app by name and prints
-          its recent entries (see streaming `app_logs_command(follow=True)`
-          through `launcher.core.process.stream` for the live-follow variant)
+    info: In-Process First
+        - Reads the logs through the Modal SDK in-process, so the packaged
+          desktop GUI (whose `sys.executable` is the app binary rather than an
+          interpreter) can fetch them without spawning anything
 
-        - Unlike the stop and volume paths, there is nothing in-process to fall
-          back to, so a bundle with no interpreter reports that plainly rather
-          than spawning the app binary at itself
+        - Falls back to the `modal app logs` CLI when modal moved or reshaped
+          the internals the in-process read drives, mirroring the `stop` path
 
     Args:
         name (str): The deployed app name
@@ -402,6 +508,22 @@ def fetch_app_logs(name: str, tail: int) -> str:
         ModalError: If credentials are missing or the app has no readable logs
     """
     ensure_authenticated()
+    try:
+        entries = _tail_logs_in_process(name, tail)
+    except (ImportError, AttributeError, TypeError) as e:
+        # Modal moved or reshaped its internals, so fall back to the CLI
+        LOGGER.warning(
+            f"Could Not Read Logs For '{name}' In-Process, Falling Back To "
+            f"The Modal CLI : {e}"
+        )
+    except ModalError:
+        raise
+    except Exception as e:
+        raise ModalError(f"Failed To Read Logs For '{name}': {e}") from e
+    else:
+        lines = _format_log_lines(entries)
+        return "\n".join(lines) + "\n" if lines else ""
+
     try:
         argv = app_logs_command(name, follow=False, tail=tail)
     except ModalError as e:
@@ -426,3 +548,88 @@ def fetch_app_logs(name: str, tail: int) -> str:
         detail = clean_subprocess_error(result.stderr)
         raise ModalError(f"Failed To Read Logs For '{name}': {detail}")
     return result.stdout
+
+
+def follow_app_logs(
+    name: str,
+    *,
+    tail: int,
+    handle: StreamHandle,
+) -> Generator[str, None, None]:
+    """
+    Live-follows a deployed Modal app's logs until the handle is cancelled
+
+    info: CLI Stream First
+        - When a `modal` CLI argv can be built, the follow is a real
+          `modal app logs -f` subprocess through
+          `launcher.core.process.stream`, which is the lowest-latency stream
+          and the behavior the CLI and dev GUI have always had
+
+        - `check=False` because cancelling kills the process, which then
+          exits non-zero through no fault of its own
+
+    info: Polling Fallback
+        - The packaged desktop GUI has no interpreter to spawn, so there the
+          follow polls the SDK-backed fetch about every 2 seconds with a
+          timestamp cursor, deduping the entries that share the cursor's
+          timestamp
+
+        - Entries therefore arrive with up to a couple of seconds of delay
+          rather than live, which is the closest the SDK allows without a
+          subprocess
+
+    info: Cancellation
+        Cooperative through `handle`. The CLI stream is killed by it and the
+        polling loop checks it several times a second while waiting
+
+    Args:
+        name (str): The deployed app name
+        tail (int): How many recent entries to show when the follow starts
+        handle (StreamHandle): Cancellation token that stops the follow
+
+    Yields:
+        The log lines
+
+    Raises:
+        ModalError: If credentials are missing or the logs cannot be read
+    """
+    try:
+        argv = app_logs_command(name, follow=True, tail=tail)
+    except ModalError:
+        LOGGER.info(
+            f"No Modal CLI Available, Following Logs For '{name}' In-Process"
+        )
+    else:
+        yield from stream(argv, check=False, handle=handle)
+        return
+
+    ensure_authenticated()
+    cursor: float | None = None
+    seen: set[tuple[float, str]] = set()
+    while not handle.cancelled:
+        since = (
+            datetime.fromtimestamp(cursor, tz=timezone.utc)
+            if cursor is not None
+            else None
+        )
+        limit = tail if cursor is None else _FOLLOW_POLL_LIMIT
+        try:
+            entries = _tail_logs_in_process(name, limit, since=since)
+        except ModalError:
+            raise
+        except Exception as e:
+            raise ModalError(
+                f"Failed To Follow Logs For '{name}': {e}. Read Them From "
+                "The Modal Dashboard Instead"
+            ) from e
+        fresh = [entry for entry in entries if entry not in seen]
+        if fresh:
+            yield from _format_log_lines(fresh)
+            cursor = max(timestamp for timestamp, _ in fresh)
+            # Only entries sharing the cursor's timestamp can reappear in the
+            # next poll (`since` is inclusive), so the dedupe set stays small
+            seen = {entry for entry in seen | set(fresh) if entry[0] == cursor}
+        waited = 0.0
+        while waited < _FOLLOW_POLL_SECONDS and not handle.cancelled:
+            time.sleep(_FOLLOW_POLL_STEP)
+            waited += _FOLLOW_POLL_STEP

--- a/docs/site/docs_md/project/changelog.md
+++ b/docs/site/docs_md/project/changelog.md
@@ -19,6 +19,28 @@ starting from **`v3.0.0`**
 
 ---
 
+## [`3.7.1`](https://github.com/svdC1/mirumoji/releases/tag/v3.7.1) - 2026-07-21
+
+This release makes the packaged desktop `GUI` read the `Modal`-hosted app's
+logs without needing a `Python` interpreter on the machine, and makes
+deletions feel instant on a hosted deployment by removing rows optimistically
+instead of waiting for the server round trip. It has no breaking changes
+
+### Fixed
+
+- `Launcher` &rarr; Reading the `Modal`-hosted app's logs from the packaged
+  desktop `GUI` failed with a `No Python Interpreter` message because the logs
+  were the one `Modal` action that still shelled out to the `modal` `CLI`.
+  Logs are now read through the `SDK` in-process like the stop and volume actions,
+  with the `CLI` kept as a fallback, and a followed stream polls in-process when no
+  `CLI` can be spawned
+
+- `Frontend` &rarr; Deleting a file, transcript, or clip only updated the
+  interface after the delete and a follow-up list refetch had both completed,
+  which on a hosted deployment left the row visible for noticeable time after
+  the click. Rows now leave the list immediately and are restored if the
+  delete turns out to have failed
+
 ## [`3.7.0`](https://github.com/svdC1/mirumoji/releases/tag/v3.7.0) - 2026-07-20
 
 This release stops a local video being uploaded once per player action,


### PR DESCRIPTION
## 3.7.1 Summary

Patch release fixing the packaged GUI's Modal log reader and the perceived latency of
deletions on a hosted deployment

### Modal Host Logs Failed In The Packaged GUI (005612c)

**Cause** &rarr;  The desktop GUI ships as a frozen `flet build` bundle where
`sys.executable` is the app binary, so `modal_cli_argv` cannot build a `modal` CLI
invocation and raises `No Python Interpreter Or 'modal' Executable Was Found`. Logs were
the only Modal operation still shelling out with no in-process fallback, which is why
deploy, stop, and volume download worked in the bundle while logs did not

**Fix** &rarr; `lifecycle.py` gains `_tail_logs_in_process`, which resolves the app id via the
public `modal.App.lookup` and drives `modal._logs.tail_logs` with a client from
`modal.client._Client.from_env` under `asyncio.run`. `fetch_app_logs` keeps its signature
and tries this path first, degrading to the existing CLI subprocess only on `ImportError`,
`AttributeError`, or `TypeError`, the same contract `_stop_in_process` uses so a Modal
release that reshapes internals downgrades instead of breaking. A new `follow_app_logs`
generator preserves the real `modal app logs -f` subprocess stream whenever an argv can be
built (no behavior change for the CLI and dev GUI) and falls back to polling `tail_logs`
with an inclusive timestamp cursor about every 2 seconds in the frozen bundle, deduping
entries that share the cursor timestamp and checking its `StreamHandle` at sub-second
granularity so Stop stays responsive. The GUI Logs panel and the CLI `--follow` branch
both route through the new functions

### Deletions Felt Slow On The Hosted Deployment (4e6d2ec)

**Cause** &rarr; The felt latency was the `await-then-refetch flow`.
A row only disappeared after the DELETE plus a full list refetch,
two serial round trips at roughly 180 ms each over the WAN, and batch file deletes are
additionally serialized server-side by `_file_delete_lock`

**Fix** &rarr; `FilesPanel`, `TranscriptsPanel`, and `ClipsPanel` now drop rows from the SWR
cache before the request with `revalidate: false`, then reconcile with a follow-up
revalidation that restores anything the server refused, including the 409 returned for a
file whose job is still in flight. Single and batch file deletes share the same optimistic
drop, and the existing `reconcileAfterDelete` cascade handling is unchanged
