### PR TITLE
V372

### DIFF
--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mirumoji-ui",
-            "version": "3.7.1",
+            "version": "3.7.2",
             "dependencies": {
                 "@fontsource/hanken-grotesk": "^5.2.8",
                 "@fontsource/newsreader": "^5.2.10",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirumoji-ui",
-    "version": "3.7.1",
+    "version": "3.7.2",
     "private": true,
     "type": "module",
     "engines": {

--- a/apps/mirumoji/pyproject.toml
+++ b/apps/mirumoji/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mirumoji"
-version = "3.7.1"
+version = "3.7.2"
 authors = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 maintainers = [{ name = "svdc", email = "svdc1mail@gmail.com" }]
 description = "Self-Hostable Japanese Language Immersion Tool"

--- a/apps/mirumoji/src/mirumoji/__init__.py
+++ b/apps/mirumoji/src/mirumoji/__init__.py
@@ -7,4 +7,4 @@ from importlib.metadata import PackageNotFoundError, version
 try:
     __version__ = version("mirumoji")
 except PackageNotFoundError:
-    __version__ = "3.7.1"
+    __version__ = "3.7.2"

--- a/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 import os
 import subprocess
+import sys
 import time
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
@@ -571,8 +572,8 @@ def follow_app_logs(
     Live-follows a deployed Modal app's logs until the handle is cancelled
 
     info: CLI Stream First
-        - When a `modal` CLI argv can be built, the follow is a real
-          `modal app logs -f` subprocess through
+        - Outside the packaged bundle, when a `modal` CLI argv can be built,
+          the follow is a real `modal app logs -f` subprocess through
           `launcher.core.process.stream`, which is the lowest-latency stream
           and the behavior the CLI and dev GUI have always had
 
@@ -580,10 +581,12 @@ def follow_app_logs(
           exits non-zero through no fault of its own
 
     info: Polling Fallback
-        - The packaged desktop GUI has no interpreter to spawn, so there the
-          follow polls the SDK-backed fetch about every 2 seconds with a
-          timestamp cursor, deduping the entries that share the cursor's
-          timestamp
+        - The packaged desktop GUI never spawns a CLI. Its own interpreter is
+          the app binary, and whatever `python` the `PATH` offers is not the
+          one carrying its modal (on Windows it can even be the Store alias
+          stub that only prints an install prompt), so there the follow polls
+          the SDK-backed fetch about every 2 seconds with a timestamp cursor,
+          deduping the entries that share the cursor's timestamp
 
         - Entries therefore arrive with up to a couple of seconds of delay
           rather than live, which is the closest the SDK allows without a
@@ -604,13 +607,18 @@ def follow_app_logs(
     Raises:
         ModalError: If credentials are missing or the logs cannot be read
     """
-    try:
-        argv = app_logs_command(name, follow=True, tail=tail)
-    except ModalError:
-        LOGGER.info(
-            f"No Modal CLI Available, Following Logs For '{name}' In-Process"
-        )
+    argv: list[str] | None = None
+    if getattr(sys, "frozen", False):
+        LOGGER.info(f"Packaged Bundle, Following Logs For '{name}' In-Process")
     else:
+        try:
+            argv = app_logs_command(name, follow=True, tail=tail)
+        except ModalError:
+            LOGGER.info(
+                f"No Modal CLI Available, Following Logs For '{name}' "
+                "In-Process"
+            )
+    if argv is not None:
         yield from stream(argv, check=False, handle=handle)
         return
 

--- a/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
+++ b/apps/mirumoji/src/mirumoji/launcher/modal/lifecycle.py
@@ -12,7 +12,6 @@ operations defined below
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import os
 import subprocess
@@ -391,6 +390,16 @@ def _tail_logs_in_process(
         caller can poll with the newest timestamp it has seen and drop the
         entries it already yielded
 
+    info: Synchronizer Loop
+        - The blocking `App.lookup` creates modal's singleton client on the
+          SDK's own synchronizer event loop, so the fetch coroutine must run
+          on that same loop
+
+        - Running it on a second loop (a plain `asyncio.run`) makes the RPC
+          lose its cancellation context and hang, with modal warning
+          `RPC request made outside of task context`, so the coroutine is
+          handed to modal's `synchronizer` the way the SDK's CLI helpers are
+
     Args:
         name (str): The deployed app name
         tail (int): How many recent entries to fetch
@@ -406,6 +415,7 @@ def _tail_logs_in_process(
     """
     import modal
     from modal._logs import tail_logs
+    from modal._utils.async_utils import synchronizer
     from modal.client import _Client
     from modal.exception import NotFoundError
 
@@ -424,7 +434,8 @@ def _tail_logs_in_process(
                 entries.append((item.timestamp, item.data))
         return entries
 
-    return asyncio.run(_collect())
+    result: list[tuple[float, str]] = synchronizer.wrap(_collect)()
+    return result
 
 
 def _format_log_lines(entries: list[tuple[float, str]]) -> list[str]:

--- a/apps/mirumoji/src/mirumoji/modal.py
+++ b/apps/mirumoji/src/mirumoji/modal.py
@@ -103,6 +103,12 @@ def python_executable() -> str | None:
           `PATH` is searched instead and `None` is returned when the machine
           has no interpreter at all
 
+    info: Store Alias Stub
+        On Windows, `PATH` carries a fake `python.exe` under
+        `Microsoft\\WindowsApps` (the app execution alias). Running it only
+        prints a Microsoft Store install prompt, so a hit from there is not
+        an interpreter and is skipped
+
     Returns:
         A path to a Python interpreter, or `None` when none is available
     """
@@ -112,7 +118,7 @@ def python_executable() -> str | None:
             return sys.executable
     for name in ("python3", "python"):
         found = shutil.which(name)
-        if found:
+        if found and "windowsapps" not in found.lower():
             return found
     return None
 

--- a/docs/site/docs_md/project/changelog.md
+++ b/docs/site/docs_md/project/changelog.md
@@ -19,6 +19,29 @@ starting from **`v3.0.0`**
 
 ---
 
+## [`3.7.2`](https://github.com/svdC1/mirumoji/releases/tag/v3.7.2) - 2026-07-21
+
+This release fixes the in-process `Modal` log reading introduced in `3.7.1`,
+which could hang instead of returning entries, and stops the packaged `GUI`
+from spawning `Windows`' fake Store `python` when following logs. It has no
+breaking changes
+
+### Fixed
+
+- `Launcher` &rarr; Reading the `Modal`-hosted app's logs in-process could hang
+  with an `RPC request made outside of task context` warning. Looking the app
+  up creates modal's client on the `SDK`'s own event loop, and the fetch then
+  ran on a second loop, where the request lost its cancellation context and
+  never completed. The fetch now runs on modal's own loop, the same way the
+  `SDK`'s `CLI` helpers run
+
+- `Launcher` &rarr; Following logs from the packaged `GUI` printed a
+  `Microsoft Store` install prompt instead of streaming. On `Windows` the
+  `PATH` carries a fake `python.exe` (the app execution alias), which the
+  bundle picked up to spawn the `modal` `CLI` with. The alias is no longer
+  treated as an interpreter anywhere, and the packaged `GUI` now always
+  follows logs in-process instead of spawning whatever `PATH` offers
+
 ## [`3.7.1`](https://github.com/svdC1/mirumoji/releases/tag/v3.7.1) - 2026-07-21
 
 This release makes the packaged desktop `GUI` read the `Modal`-hosted app's


### PR DESCRIPTION
### 3.7.2 Summary

This release fixes the in-process `Modal` log reading introduced in `3.7.1`,
which could hang instead of returning entries, and stops the packaged `GUI`
from spawning `Windows`' fake Store `python` when following logs. It has no
breaking changes

### Fixed

- `Launcher` &rarr; Reading the `Modal`-hosted app's logs in-process could hang
  with an `RPC request made outside of task context` warning. Looking the app
  up creates modal's client on the `SDK`'s own event loop, and the fetch then
  ran on a second loop, where the request lost its cancellation context and
  never completed. The fetch now runs on modal's own loop, the same way the
  `SDK`'s `CLI` helpers run

- `Launcher` &rarr; Following logs from the packaged `GUI` printed a
  `Microsoft Store` install prompt instead of streaming. On `Windows` the
  `PATH` carries a fake `python.exe` (the app execution alias), which the
  bundle picked up to spawn the `modal` `CLI` with. The alias is no longer
  treated as an interpreter anywhere, and the packaged `GUI` now always
  follows logs in-process instead of spawning whatever `PATH` offers